### PR TITLE
[codex] Refine reader UI contrast

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,8 @@ import { useArticlesStore } from './store/articles'
 import { useSSE } from './hooks/useSSE'
 import { useOnlineStatus } from './hooks/useOnlineStatus'
 import type { Feed } from './types'
+import { Inbox, PanelLeftClose, PanelLeftOpen } from 'lucide-react'
+import { IconButton, Kbd } from './components/ui'
 
 type AppView = 'briefing' | 'feed' | 'stats'
 
@@ -175,7 +177,7 @@ function AuthenticatedApp({ onLogout }: { onLogout: () => void }) {
           onClick={() => setShowHelp(false)}
         >
           <div
-            className="bg-bg-surface border border-border-default rounded-2xl p-6 w-80 shadow-2xl"
+            className="bg-bg-surface rounded-2xl p-6 w-80 shadow-2xl"
             onClick={e => e.stopPropagation()}
           >
             <h2 className="text-sm font-semibold text-text-primary mb-4 text-center tracking-wide">Raccourcis clavier</h2>
@@ -192,9 +194,7 @@ function AuthenticatedApp({ onLogout }: { onLogout: () => void }) {
               ].map(([key, desc]) => (
                 <div key={key} className="flex items-center justify-between">
                   <span className="text-xs text-text-muted">{desc}</span>
-                  <kbd className="px-2 py-0.5 bg-bg-elevated rounded text-xs font-mono text-text-secondary border border-border-subtle">
-                    {key}
-                  </kbd>
+                  <Kbd>{key}</Kbd>
                 </div>
               ))}
             </div>
@@ -305,39 +305,29 @@ function EmptyReaderState({
     <div className="flex flex-col h-full">
       {/* Toolbar stub to align with ReaderView toolbar */}
       <div className="flex items-center px-3 py-3 border-b border-border-subtle bg-bg-surface flex-shrink-0">
-        <button
+        <IconButton
           onClick={onToggleSidebar}
-          className="p-1.5 rounded-lg hover:bg-bg-hover transition-colors text-text-secondary hover:text-text-primary"
-          title={sidebarOpen ? 'Hide sidebar  [' : 'Show sidebar  ['}
-        >
-          {sidebarOpen ? (
-            // PanelLeftClose
-            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <rect width="18" height="18" x="3" y="3" rx="2"/><path d="M9 3v18"/><path d="m16 15-3-3 3-3"/>
-            </svg>
-          ) : (
-            // PanelLeftOpen
-            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <rect width="18" height="18" x="3" y="3" rx="2"/><path d="M9 3v18"/><path d="m14 9 3 3-3 3"/>
-            </svg>
-          )}
-        </button>
+          icon={sidebarOpen ? PanelLeftClose : PanelLeftOpen}
+          label={sidebarOpen ? 'Masquer la sidebar  [' : 'Afficher la sidebar  ['}
+        />
       </div>
       <div className="flex flex-col items-center justify-center flex-1 text-center p-8">
-        <div className="text-5xl mb-4 opacity-30">◉</div>
-        <h2 className="text-base font-semibold text-text-secondary mb-1">
-          Select an article
+        <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-md bg-bg-surface text-accent-blue">
+          <Inbox className="h-6 w-6" />
+        </div>
+        <h2 className="text-base font-semibold text-text-primary mb-1">
+          Sélectionne un article
         </h2>
         <p className="text-xs text-text-muted max-w-xs leading-relaxed">
-          <kbd className="px-1.5 py-0.5 bg-bg-elevated rounded text-xs font-mono">j</kbd>
+          <Kbd>j</Kbd>
           {' / '}
-          <kbd className="px-1.5 py-0.5 bg-bg-elevated rounded text-xs font-mono">k</kbd>
-          {' '}navigate{'  ·  '}
-          <kbd className="px-1.5 py-0.5 bg-bg-elevated rounded text-xs font-mono">r</kbd>
-          {' '}read{'  ·  '}
-          <kbd className="px-1.5 py-0.5 bg-bg-elevated rounded text-xs font-mono">b</kbd>
-          {' '}bookmark{'  ·  '}
-          <kbd className="px-1.5 py-0.5 bg-bg-elevated rounded text-xs font-mono">[</kbd>
+          <Kbd>k</Kbd>
+          {' '}naviguer{'  ·  '}
+          <Kbd>r</Kbd>
+          {' '}lu{'  ·  '}
+          <Kbd>b</Kbd>
+          {' '}favori{'  ·  '}
+          <Kbd>[</Kbd>
           {' '}sidebar
         </p>
       </div>

--- a/frontend/src/components/ArticleCard.tsx
+++ b/frontend/src/components/ArticleCard.tsx
@@ -1,10 +1,11 @@
 import { useRef, useState } from 'react'
 import { formatDistanceToNow } from 'date-fns'
-import { Bookmark, BookmarkCheck } from 'lucide-react'
+import { fr } from 'date-fns/locale'
+import { AlertTriangle, Bookmark, BookmarkCheck, ThumbsDown, ThumbsUp } from 'lucide-react'
 import type { ArticleListItem } from '../types'
-import { ScoreBar } from './ScoreBar'
 import { ReadTimeBadge } from './ReadTimeBadge'
 import { useArticlesStore } from '../store/articles'
+import { ScoreBadge } from './ui'
 
 interface ArticleCardProps {
   article: ArticleListItem
@@ -51,20 +52,20 @@ export function ArticleCard({ article, selected, onClick }: ArticleCardProps) {
   }
 
   const relativeDate = article.published_at
-    ? formatDistanceToNow(new Date(article.published_at), { addSuffix: true })
-    : formatDistanceToNow(new Date(article.created_at), { addSuffix: true })
+    ? formatDistanceToNow(new Date(article.published_at), { addSuffix: true, locale: fr })
+    : formatDistanceToNow(new Date(article.created_at), { addSuffix: true, locale: fr })
 
   const isRead = Boolean(article.read_at)
 
   return (
     <div
       className={`
-        relative overflow-hidden cursor-pointer select-none
+        group relative cursor-pointer select-none overflow-hidden
         border-b border-border-subtle
-        transition-colors duration-150
+        transition-all duration-150
         ${selected
-          ? 'bg-bg-elevated border-l-2 border-l-accent-blue'
-          : 'hover:bg-bg-hover'
+          ? 'bg-accent-blue/8 shadow-[inset_3px_0_0_var(--color-accent-blue)]'
+          : 'hover:bg-bg-hover/80'
         }
         ${isRead ? 'opacity-60' : ''}
       `}
@@ -90,27 +91,20 @@ export function ArticleCard({ article, selected, onClick }: ArticleCardProps) {
         </div>
       )}
 
-      <div className="p-3">
-        <ScoreBar score={article.score} />
-
-        {/* Tags */}
-        {article.tags.length > 0 && (
-          <div className="flex flex-wrap gap-1 mb-2">
-            {article.tags.slice(0, 3).map(tag => (
-              <span
-                key={tag}
-                className="px-1.5 py-0.5 bg-bg-elevated rounded text-xs text-text-muted font-medium"
-              >
-                {tag}
-              </span>
-            ))}
+      <div className="p-3.5">
+        <div className="mb-2 flex items-start justify-between gap-3">
+          <div className="min-w-0 text-[11px] leading-5 text-text-muted">
+            <span className="font-semibold text-text-secondary">{article.feed_name}</span>
+            <span className="px-1.5 text-border-default">/</span>
+            <span>{relativeDate}</span>
           </div>
-        )}
+          <ScoreBadge score={article.score} compact />
+        </div>
 
         {/* Title */}
         <h3
           className={`
-            text-sm font-semibold leading-snug mb-1 line-clamp-2
+            mb-2 line-clamp-2 text-[15px] font-semibold leading-snug
             ${isRead ? 'text-text-secondary' : 'text-text-primary'}
           `}
         >
@@ -119,36 +113,48 @@ export function ArticleCard({ article, selected, onClick }: ArticleCardProps) {
 
         {/* Summary bullets */}
         {article.summary_bullets.length > 0 && (
-          <ul className="mb-2 space-y-0.5">
+          <ul className="mb-2.5 space-y-1">
             {article.summary_bullets.slice(0, 2).map((bullet, i) => (
-              <li key={i} className="text-xs text-text-secondary leading-relaxed flex gap-1">
-                <span className="text-text-muted flex-shrink-0">•</span>
+              <li key={i} className="flex gap-1.5 text-xs leading-relaxed text-text-secondary">
+                <span className="mt-[0.55em] h-1 w-1 flex-shrink-0 rounded-full bg-accent-blue/70" />
                 <span className="line-clamp-1">{bullet}</span>
               </li>
             ))}
           </ul>
         )}
 
+        {/* Tags */}
+        {article.tags.length > 0 && (
+          <div className="mb-2.5 flex flex-wrap gap-1">
+            {article.tags.slice(0, 4).map(tag => (
+              <span
+                key={tag}
+                className="rounded bg-bg-elevated/80 px-1.5 py-0.5 text-[10px] font-medium text-text-muted"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
+
         {/* Meta */}
-        <div className="flex items-center justify-between mt-1">
+        <div className="mt-1 flex items-center justify-between gap-2">
           <div className="flex items-center gap-2 text-xs text-text-muted min-w-0">
-            <span className="truncate font-medium">{article.feed_name}</span>
-            <span className="flex-shrink-0">·</span>
-            <span className="flex-shrink-0">{relativeDate}</span>
             <ReadTimeBadge minutes={article.reading_time} />
+            {isRead && <span className="rounded bg-bg-elevated/80 px-1.5 py-0.5 text-[10px]">Lu</span>}
           </div>
           <div className="flex items-center gap-1 flex-shrink-0 ml-2">
             {article.user_feedback === 1 && (
-              <span className="text-xs text-accent-green" title="Liked">👍</span>
+              <ThumbsUp className="h-3.5 w-3.5 text-accent-green" />
             )}
             {article.user_feedback === -1 && (
-              <span className="text-xs text-red-400" title="Disliked">👎</span>
+              <ThumbsDown className="h-3.5 w-3.5 text-accent-red" />
             )}
             {article.bookmarked && (
               <BookmarkCheck className="w-3.5 h-3.5 text-accent-blue" />
             )}
             {article.extraction_failed && (
-              <span className="text-xs text-accent-yellow" title="Extraction failed">⚠</span>
+              <AlertTriangle className="h-3.5 w-3.5 text-accent-yellow" />
             )}
           </div>
         </div>

--- a/frontend/src/components/ArticleList.tsx
+++ b/frontend/src/components/ArticleList.tsx
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Virtuoso } from 'react-virtuoso'
-import { Loader2, RefreshCw, ArrowUpDown, BarChart2, Clock, CheckCheck, Star, Search, X, Settings, Sparkles, LogOut, Newspaper } from 'lucide-react'
+import { Loader2, RefreshCw, ArrowUpDown, BarChart2, Clock, CheckCheck, Star, Search, X, Settings2, Sparkles, LogOut, Newspaper, Inbox, SlidersHorizontal } from 'lucide-react'
 import { ArticleCard } from './ArticleCard'
 import { CategoryTabs } from './CategoryTabs'
 import { StatsView } from './StatsView'
 import { useArticlesStore } from '../store/articles'
 import type { Feed } from '../types'
+import { IconButton, SegmentedControl } from './ui'
 
 interface ArticleListProps {
   feeds: Feed[]
@@ -124,6 +125,11 @@ export function ArticleList({ feeds, onSelect, selectedId, onOpenFeedManager, cu
   }, [loading, hasMore, articles.length])
 
   const unreadCount = filter.status === 'unread' ? articles.length : null
+  const viewOptions = [
+    { value: 'briefing' as const, label: 'Briefing', icon: Sparkles },
+    { value: 'feed' as const, label: 'Articles', icon: Newspaper },
+    { value: 'stats' as const, label: 'Stats', icon: BarChart2 },
+  ]
 
   const isSearchActive = Boolean(searchQuery.trim())
   const displayedArticles = isSearchActive ? searchResults : articles
@@ -145,71 +151,35 @@ export function ArticleList({ feeds, onSelect, selectedId, onOpenFeedManager, cu
       )}
 
       {/* Header */}
-      <div className="flex items-center justify-between px-3 py-2 border-b border-border-subtle flex-shrink-0">
-        <div className="flex items-center gap-1.5">
-          <span className="text-xs font-semibold text-text-secondary tracking-wide">
-            MakhalReader
-          </span>
-          {/* Feed toggle */}
-          <button
-            onClick={() => onViewChange('feed')}
-            className={`flex items-center gap-1 px-1.5 py-0.5 rounded-md text-[11px] font-medium transition-colors ${
-              currentView === 'feed'
-                ? 'bg-accent-blue/15 text-accent-blue'
-                : 'text-text-muted hover:text-text-primary hover:bg-bg-hover'
-            }`}
-            title="Articles"
-          >
-            <Newspaper className="w-3 h-3" />
-            Articles
-          </button>
-          {/* Briefing toggle */}
-          <button
-            onClick={() => onViewChange('briefing')}
-            className={`flex items-center gap-1 px-1.5 py-0.5 rounded-md text-[11px] font-medium transition-colors ${
-              currentView === 'briefing'
-                ? 'bg-accent-blue/15 text-accent-blue'
-                : 'text-text-muted hover:text-text-primary hover:bg-bg-hover'
-            }`}
-            title="Le Briefing du jour"
-          >
-            <Sparkles className="w-3 h-3" />
-            Briefing
-          </button>
-          {/* Stats toggle */}
-          <button
-            onClick={() => onViewChange(currentView === 'stats' ? 'feed' : 'stats')}
-            className={`flex items-center gap-1 px-1.5 py-0.5 rounded-md text-[11px] font-medium transition-colors ${
-              currentView === 'stats'
-                ? 'bg-accent-blue/15 text-accent-blue'
-                : 'text-text-muted hover:text-text-primary hover:bg-bg-hover'
-            }`}
-            title="Statistiques de lecture"
-          >
-            <BarChart2 className="w-3 h-3" />
-            Stats
-          </button>
-        </div>
-        <div className="flex items-center gap-0.5">
+      <div className="border-b border-border-subtle bg-bg-surface/95 px-3 py-3 flex-shrink-0">
+        <div className="mb-3 flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <div className="flex h-8 w-8 items-center justify-center rounded-md bg-accent-blue/12 text-accent-blue">
+                <Inbox className="h-4 w-4" />
+              </div>
+              <div className="min-w-0">
+                <h1 className="truncate text-sm font-semibold leading-5 text-text-primary">MakhalReader</h1>
+                <p className="truncate text-[11px] text-text-muted">Moins lire. Plus savoir.</p>
+              </div>
+            </div>
+          </div>
+          <div className="flex items-center gap-1">
           {/* Search — hidden only in Stats */}
           {showArticleList && (
-            <button
+            <IconButton
               onClick={openSearch}
-              className="p-1.5 rounded-md hover:bg-bg-hover transition-colors text-text-muted hover:text-text-primary"
-              title="Search  /"
-            >
-              <Search className="w-3.5 h-3.5" />
-            </button>
+              icon={Search}
+              label="Rechercher  /"
+            />
           )}
           {/* Refresh — hidden only in Stats */}
           {showArticleList && (
-            <button
+            <IconButton
               onClick={() => fetchArticles(true)}
-              className="p-1.5 rounded-md hover:bg-bg-hover transition-colors text-text-muted hover:text-text-primary"
-              title="Refresh"
-            >
-              <RefreshCw className="w-3.5 h-3.5" />
-            </button>
+              icon={RefreshCw}
+              label="Actualiser"
+            />
           )}
           {/* Mark all read */}
           {showArticleList && filter.status !== 'read' && (
@@ -217,35 +187,40 @@ export function ArticleList({ feeds, onSelect, selectedId, onOpenFeedManager, cu
               onClick={handleMarkAllRead}
               className={`flex items-center gap-1 rounded-md transition-all duration-150 text-xs font-medium ${
                 confirmingReadAll
-                  ? 'px-2 py-1 bg-red-500/15 text-red-400 hover:bg-red-500/25 ring-1 ring-red-500/40'
-                  : 'p-1.5 text-text-muted hover:bg-bg-hover hover:text-text-primary'
+                  ? 'h-8 px-2 border border-accent-red/40 bg-accent-red/12 text-accent-red'
+                  : 'h-8 w-8 justify-center border border-transparent bg-transparent text-text-muted hover:bg-bg-hover hover:text-text-primary'
               }`}
-              title={confirmingReadAll ? 'Tap again to confirm' : 'Mark all as read'}
+              title={confirmingReadAll ? 'Confirmer' : 'Tout marquer comme lu'}
             >
-              <CheckCheck className="w-3.5 h-3.5 flex-shrink-0" />
-              {confirmingReadAll && <span>Confirm?</span>}
+              <CheckCheck className="w-4 h-4 flex-shrink-0" />
+              {confirmingReadAll && <span>Confirmer</span>}
             </button>
           )}
           {/* Feed manager */}
-          <button
+          <IconButton
             onClick={onOpenFeedManager}
-            className="p-1.5 rounded-md hover:bg-bg-hover transition-colors text-text-muted hover:text-text-primary"
-            title="Gérer les feeds"
-          >
-            <Settings className="w-3.5 h-3.5" />
-          </button>
+            icon={Settings2}
+            label="Gérer les feeds"
+          />
           {/* Logout */}
-          <button
+          <IconButton
             onClick={async () => {
               await fetch('/auth/logout', { method: 'POST', credentials: 'include' })
               onLogout()
             }}
-            className="p-1.5 rounded-md hover:bg-bg-hover transition-colors text-text-muted hover:text-red-400"
-            title="Se déconnecter"
-          >
-            <LogOut className="w-3.5 h-3.5" />
-          </button>
+            icon={LogOut}
+            label="Se déconnecter"
+            className="hover:text-accent-red"
+          />
+          </div>
         </div>
+
+        <SegmentedControl
+          value={currentView}
+          options={viewOptions}
+          onChange={onViewChange}
+          className="grid w-full grid-cols-3"
+        />
       </div>
 
       {/* Stats view — replaces list when active */}
@@ -255,7 +230,7 @@ export function ArticleList({ feeds, onSelect, selectedId, onOpenFeedManager, cu
 
       {/* Search bar */}
       {showArticleList && searchOpen && (
-        <div className="flex items-center gap-2 px-3 py-2 border-b border-border-subtle bg-bg-surface flex-shrink-0">
+        <div className="flex items-center gap-2 border-b border-border-subtle bg-bg-base px-3 py-2.5 flex-shrink-0">
           <Search className="w-3.5 h-3.5 text-text-muted flex-shrink-0" />
           <input
             ref={searchInputRef}
@@ -263,7 +238,7 @@ export function ArticleList({ feeds, onSelect, selectedId, onOpenFeedManager, cu
             value={searchQuery}
             onChange={e => setSearchQuery(e.target.value)}
             onKeyDown={e => { if (e.key === 'Escape') closeSearch() }}
-            placeholder="Search title, feed, tag…"
+            placeholder="Titre, source, tag..."
             className="flex-1 bg-transparent text-sm text-text-primary placeholder-text-muted outline-none"
           />
           {isSearchActive && (
@@ -281,35 +256,48 @@ export function ArticleList({ feeds, onSelect, selectedId, onOpenFeedManager, cu
       {showArticleList && <CategoryTabs feeds={feeds} />}
 
       {/* Toolbar — hidden only in Stats */}
-      {showArticleList && <div className="flex items-center gap-1.5 px-3 py-1.5 border-b border-border-subtle flex-shrink-0 flex-wrap">
+      {showArticleList && <div className="flex flex-col gap-2 border-b border-border-subtle bg-bg-base/70 px-3 py-2.5 flex-shrink-0">
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.12em] text-text-muted">
+            <SlidersHorizontal className="h-3.5 w-3.5" />
+            Triage
+          </div>
+          {unreadCount !== null && unreadCount > 0 && (
+          <span className="rounded bg-bg-elevated px-2 py-0.5 text-[11px] text-text-muted tabular-nums">
+              {unreadCount} à lire
+            </span>
+          )}
+        </div>
+
+        <div className="flex items-center gap-1.5 flex-wrap">
         {/* Status toggle */}
-        <div className="flex rounded-md overflow-hidden border border-border-default text-xs">
+        <div className="flex rounded-md overflow-hidden bg-bg-elevated/70 p-0.5 text-xs">
           <button
             onClick={() => setFilter({ status: 'unread', bookmarked: false })}
-            className={`px-2 py-1 transition-colors ${
+            className={`rounded px-2 py-1 transition-colors ${
               filter.status === 'unread' && !filter.bookmarked
-                ? 'bg-accent-blue text-white'
+                ? 'bg-accent-blue text-bg-base font-semibold'
                 : 'text-text-muted hover:text-text-primary hover:bg-bg-hover'
             }`}
           >
-            Unread
+            Non lus
           </button>
           <button
             onClick={() => setFilter({ status: 'all', bookmarked: false })}
-            className={`px-2 py-1 border-l border-border-default transition-colors ${
+            className={`rounded px-2 py-1 transition-colors ${
               filter.status === 'all' && !filter.bookmarked
-                ? 'bg-accent-blue text-white'
+                ? 'bg-accent-blue text-bg-base font-semibold'
                 : 'text-text-muted hover:text-text-primary hover:bg-bg-hover'
             }`}
           >
-            All
+            Tous
           </button>
         </div>
 
         {/* Sort toggle */}
         <button
           onClick={() => setFilter({ sort: filter.sort === 'score' ? 'date' : 'score' })}
-          className="flex items-center gap-1 px-2 py-1 rounded-md border border-border-default text-xs text-text-muted hover:text-text-primary hover:bg-bg-hover transition-colors"
+          className="flex items-center gap-1 rounded-md px-2 py-1 text-xs text-text-muted transition-colors hover:bg-bg-hover hover:text-text-primary"
           title={filter.sort === 'score' ? 'Sorted by score — click for date' : 'Sorted by date — click for score'}
         >
           {filter.sort === 'score'
@@ -321,12 +309,12 @@ export function ArticleList({ feeds, onSelect, selectedId, onOpenFeedManager, cu
         </button>
 
         {/* Min score filter */}
-        <div className="flex rounded-md overflow-hidden border border-border-default text-xs">
+        <div className="flex rounded-md overflow-hidden bg-bg-elevated/70 p-0.5 text-xs">
           {([0, 6, 8] as const).map(s => (
             <button
               key={s}
               onClick={() => setFilter({ minScore: s })}
-              className={`px-2 py-1 transition-colors ${s > 0 ? 'border-l border-border-default' : ''} ${
+              className={`rounded px-2 py-1 transition-colors ${
                 filter.minScore === s
                   ? s === 0 ? 'bg-bg-elevated text-text-primary'
                     : s === 6 ? 'bg-accent-yellow/20 text-accent-yellow'
@@ -335,17 +323,11 @@ export function ArticleList({ feeds, onSelect, selectedId, onOpenFeedManager, cu
               }`}
               title={s === 0 ? 'All scores' : `Score ≥ ${s}`}
             >
-              {s === 0 ? 'All' : `${s}+`}
+              {s === 0 ? 'Tous' : `${s}+`}
             </button>
           ))}
         </div>
-
-        {/* Unread count */}
-        {unreadCount !== null && unreadCount > 0 && (
-          <span className="ml-auto text-xs text-text-muted tabular-nums">
-            {unreadCount}
-          </span>
-        )}
+        </div>
       </div>}
 
       {/* Article list — empty state + list, hidden only in Stats */}
@@ -354,7 +336,9 @@ export function ArticleList({ feeds, onSelect, selectedId, onOpenFeedManager, cu
           {/* Empty state */}
           {!loading && !isSearching && displayedArticles.length === 0 && (
             <div className="flex flex-col items-center justify-center flex-1 text-center p-8">
-              <div className="text-4xl mb-3 opacity-20">◎</div>
+              <div className="mb-3 flex h-11 w-11 items-center justify-center rounded-md bg-bg-surface text-text-muted">
+                <Inbox className="h-5 w-5" />
+              </div>
               <p className="text-sm font-medium text-text-secondary mb-1">
                 {isSearchActive ? 'Aucun résultat' : 'Aucun article'}
               </p>

--- a/frontend/src/components/CategoryTabs.tsx
+++ b/frontend/src/components/CategoryTabs.tsx
@@ -1,4 +1,4 @@
-import { Bookmark } from 'lucide-react'
+import { Bookmark, Library } from 'lucide-react'
 import { useArticlesStore } from '../store/articles'
 import type { Feed } from '../types'
 
@@ -9,8 +9,8 @@ interface CategoryTabsProps {
 export function CategoryTabs({ feeds }: CategoryTabsProps) {
   const { filter, setFilter, articles } = useArticlesStore()
 
-  const categories = ['All', ...Array.from(new Set(feeds.map(f => f.category))).sort()]
-  const activeCategory = filter.bookmarked ? 'Bookmarks' : (filter.category ?? 'All')
+  const categories = ['Tous', ...Array.from(new Set(feeds.map(f => f.category))).sort()]
+  const activeCategory = filter.bookmarked ? 'Favoris' : (filter.category ?? 'Tous')
 
   // Compute unread counts per category from currently loaded articles.
   // Only shown in unread/all modes (not when already filtering to read-only).
@@ -26,9 +26,9 @@ export function CategoryTabs({ feeds }: CategoryTabsProps) {
   const totalCount = [...categoryCounts.values()].reduce((s, n) => s + n, 0)
 
   const handleCategoryClick = (cat: string) => {
-    if (cat === 'Bookmarks') {
+    if (cat === 'Favoris') {
       setFilter({ bookmarked: true, category: null })
-    } else if (cat === 'All') {
+    } else if (cat === 'Tous') {
       setFilter({ bookmarked: false, category: null })
     } else {
       setFilter({ bookmarked: false, category: cat })
@@ -38,25 +38,26 @@ export function CategoryTabs({ feeds }: CategoryTabsProps) {
   return (
     <div className="flex items-center gap-1 px-3 py-2 overflow-x-auto scrollbar-hide border-b border-border-subtle">
       {categories.map(cat => {
-        const count = cat === 'All' ? totalCount : (categoryCounts.get(cat) ?? 0)
+        const count = cat === 'Tous' ? totalCount : (categoryCounts.get(cat) ?? 0)
         const isActive = activeCategory === cat
         return (
           <button
             key={cat}
             onClick={() => handleCategoryClick(cat)}
             className={`
-              flex-shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium transition-colors whitespace-nowrap
+              flex-shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors whitespace-nowrap
               ${isActive
-                ? 'bg-accent-blue text-white'
-                : 'bg-bg-elevated text-text-secondary hover:bg-bg-hover hover:text-text-primary'
+                ? 'bg-accent-blue/12 text-accent-blue'
+                : 'text-text-secondary hover:bg-bg-hover hover:text-text-primary'
               }
             `}
           >
+            {cat === 'Tous' && <Library className="h-3 w-3" />}
             {cat}
             {count > 0 && filter.status !== 'read' && (
               <span className={`
                 text-[10px] font-semibold tabular-nums leading-none px-1 py-0.5 rounded-full min-w-[16px] text-center
-                ${isActive ? 'bg-white/25 text-white' : 'bg-bg-surface text-text-muted'}
+                ${isActive ? 'bg-accent-blue/18 text-accent-blue' : 'bg-bg-elevated text-text-muted'}
               `}>
                 {count > 99 ? '99+' : count}
               </span>
@@ -65,21 +66,21 @@ export function CategoryTabs({ feeds }: CategoryTabsProps) {
         )
       })}
       <button
-        onClick={() => handleCategoryClick('Bookmarks')}
+        onClick={() => handleCategoryClick('Favoris')}
         className={`
-          flex-shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium transition-colors whitespace-nowrap
-          ${activeCategory === 'Bookmarks'
-            ? 'bg-accent-blue text-white'
-            : 'bg-bg-elevated text-text-secondary hover:bg-bg-hover hover:text-text-primary'
+          flex-shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors whitespace-nowrap
+          ${activeCategory === 'Favoris'
+            ? 'bg-accent-blue/12 text-accent-blue'
+            : 'text-text-secondary hover:bg-bg-hover hover:text-text-primary'
           }
         `}
       >
         <Bookmark className="w-3 h-3" />
-        Bookmarks
+        Favoris
         {bookmarkCount > 0 && (
           <span className={`
             text-[10px] font-semibold tabular-nums leading-none px-1 py-0.5 rounded-full min-w-[16px] text-center
-            ${activeCategory === 'Bookmarks' ? 'bg-white/25 text-white' : 'bg-bg-surface text-text-muted'}
+            ${activeCategory === 'Favoris' ? 'bg-accent-blue/18 text-accent-blue' : 'bg-bg-elevated text-text-muted'}
           `}>
             {bookmarkCount > 99 ? '99+' : bookmarkCount}
           </span>

--- a/frontend/src/components/LoginView.tsx
+++ b/frontend/src/components/LoginView.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from 'react'
+import { Loader2, LockKeyhole, ShieldCheck } from 'lucide-react'
 
 interface Props {
   onLogin: () => void
@@ -51,64 +52,27 @@ export function LoginView({ onLogin }: Props) {
   }
 
   return (
-    <div
-      style={{ fontFamily: 'system-ui, -apple-system, sans-serif' }}
-      className="min-h-screen w-full flex items-center justify-center bg-[#0a0a0b] overflow-hidden relative"
-    >
-      {/* Background glow */}
-      <div className="pointer-events-none absolute inset-0 overflow-hidden">
-        <div
-          className="absolute rounded-full opacity-20 blur-3xl"
-          style={{
-            width: 600,
-            height: 600,
-            top: '50%',
-            left: '50%',
-            transform: 'translate(-50%, -60%)',
-            background: 'radial-gradient(circle, #6366f1 0%, #8b5cf6 40%, transparent 70%)',
-          }}
-        />
-      </div>
-
-      {/* Subtle grid */}
-      <div
-        className="pointer-events-none absolute inset-0 opacity-[0.035]"
-        style={{
-          backgroundImage:
-            'linear-gradient(rgba(255,255,255,0.5) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.5) 1px, transparent 1px)',
-          backgroundSize: '52px 52px',
-        }}
-      />
-
-      <div className="relative z-10 w-full max-w-[380px] px-6">
+    <div className="relative flex min-h-screen w-full items-center justify-center overflow-hidden bg-bg-base px-6">
+      <div className="relative z-10 w-full max-w-[390px]">
 
         {/* Logo */}
         <div className="text-center mb-10 select-none">
-          <div
-            className="inline-flex items-center justify-center w-14 h-14 rounded-2xl mb-5"
-            style={{ background: 'linear-gradient(135deg, #6366f1, #8b5cf6)' }}
-          >
-            <span style={{ fontSize: 26, color: 'white', lineHeight: 1 }}>◉</span>
+          <div className="mb-5 inline-flex h-14 w-14 items-center justify-center rounded-md bg-accent-blue/12 text-accent-blue">
+            <LockKeyhole className="h-6 w-6" />
           </div>
-          <h1 style={{ color: '#f4f4f5', fontSize: 22, fontWeight: 600, letterSpacing: '-0.03em', margin: 0 }}>
+          <h1 className="text-[22px] font-semibold text-text-primary">
             MakhalReader
           </h1>
-          <p style={{ color: '#71717a', fontSize: 13, marginTop: 6 }}>
-            Your private intelligence feed
+          <p className="mt-1.5 text-sm text-text-muted">
+            Ton flux privé, trié avant lecture.
           </p>
         </div>
 
         {/* Card */}
         <form
           onSubmit={submit}
-          style={{
-            background: 'rgba(255,255,255,0.04)',
-            border: '1px solid rgba(255,255,255,0.08)',
-            borderRadius: 20,
-            padding: '28px 28px 24px',
-            backdropFilter: 'blur(12px)',
-            animation: shake ? 'shake 0.4s ease' : undefined,
-          }}
+          className="rounded-md bg-bg-surface p-6 shadow-2xl"
+          style={{ animation: shake ? 'shake 0.4s ease' : undefined }}
         >
           <style>{`
             @keyframes shake {
@@ -121,9 +85,9 @@ export function LoginView({ onLogin }: Props) {
           `}</style>
 
           {/* Password field */}
-          <div style={{ marginBottom: 16 }}>
-            <label style={{ display: 'block', fontSize: 12, color: '#a1a1aa', marginBottom: 7, fontWeight: 500 }}>
-              Password
+          <div className="mb-4">
+            <label className="mb-1.5 block text-xs font-medium text-text-secondary">
+              Mot de passe
             </label>
             <input
               ref={inputRef}
@@ -132,64 +96,28 @@ export function LoginView({ onLogin }: Props) {
               onChange={e => { setPassword(e.target.value); setError(null) }}
               placeholder="••••••••••••••••"
               autoComplete="current-password"
-              style={{
-                width: '100%',
-                padding: '11px 14px',
-                borderRadius: 10,
-                border: `1.5px solid ${error ? 'rgba(239,68,68,0.5)' : 'rgba(255,255,255,0.1)'}`,
-                background: 'rgba(255,255,255,0.06)',
-                color: '#f4f4f5',
-                fontSize: 14,
-                outline: 'none',
-                boxSizing: 'border-box',
-                transition: 'border-color 0.15s',
-              }}
-              onFocus={e => {
-                if (!error) e.target.style.borderColor = 'rgba(99,102,241,0.7)'
-              }}
-              onBlur={e => {
-                if (!error) e.target.style.borderColor = 'rgba(255,255,255,0.1)'
-              }}
+              className={`w-full rounded-md border bg-bg-elevated px-3 py-2.5 text-sm text-text-primary placeholder-text-muted outline-none transition-colors ${
+                error ? 'border-accent-red/60' : 'border-transparent focus:border-accent-blue/45'
+              }`}
             />
             {error && (
-              <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 8 }}>
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#f87171" strokeWidth="2.5" strokeLinecap="round">
-                  <circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>
-                </svg>
-                <span style={{ fontSize: 12, color: '#f87171' }}>{error}</span>
+              <div className="mt-2 flex items-center gap-1.5 text-xs text-accent-red">
+                <span>{error}</span>
               </div>
             )}
           </div>
 
           {/* Remember toggle */}
           <div
-            style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 22, cursor: 'pointer', userSelect: 'none' }}
+            className="mb-5 flex cursor-pointer select-none items-center gap-2.5"
             onClick={() => setRemember(v => !v)}
           >
             {/* Toggle pill */}
-            <div style={{
-              position: 'relative',
-              width: 36,
-              height: 20,
-              borderRadius: 99,
-              background: remember ? '#6366f1' : 'rgba(255,255,255,0.1)',
-              transition: 'background 0.2s',
-              flexShrink: 0,
-            }}>
-              <div style={{
-                position: 'absolute',
-                top: 3,
-                left: remember ? 19 : 3,
-                width: 14,
-                height: 14,
-                borderRadius: '50%',
-                background: 'white',
-                transition: 'left 0.2s',
-                boxShadow: '0 1px 3px rgba(0,0,0,0.4)',
-              }}/>
+            <div className={`relative h-5 w-9 flex-shrink-0 rounded-full transition-colors ${remember ? 'bg-accent-blue' : 'bg-bg-elevated'}`}>
+              <div className={`absolute top-1 h-3 w-3 rounded-full bg-bg-base transition-all ${remember ? 'left-5' : 'left-1'}`} />
             </div>
-            <span style={{ fontSize: 13, color: '#a1a1aa' }}>
-              Keep me signed in
+            <span className="text-sm text-text-secondary">
+              Garder la session ouverte
             </span>
           </div>
 
@@ -197,37 +125,21 @@ export function LoginView({ onLogin }: Props) {
           <button
             type="submit"
             disabled={loading || !password}
-            style={{
-              width: '100%',
-              padding: '11px',
-              borderRadius: 10,
-              border: 'none',
-              cursor: loading || !password ? 'not-allowed' : 'pointer',
-              background: loading || !password
-                ? 'rgba(99,102,241,0.35)'
-                : 'linear-gradient(135deg, #6366f1, #8b5cf6)',
-              color: loading || !password ? 'rgba(255,255,255,0.4)' : 'white',
-              fontSize: 14,
-              fontWeight: 600,
-              transition: 'all 0.15s',
-              letterSpacing: '-0.01em',
-            }}
+            className="flex w-full items-center justify-center gap-2 rounded-md bg-accent-blue px-3 py-2.5 text-sm font-semibold text-bg-base transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-45"
           >
             {loading ? (
-              <span style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8 }}>
-                <svg style={{ animation: 'spin 0.8s linear infinite' }} width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
-                  <path d="M21 12a9 9 0 11-6.219-8.56"/>
-                </svg>
-                <style>{'@keyframes spin{to{transform:rotate(360deg)}}'}</style>
-                Signing in…
-              </span>
-            ) : 'Sign in →'}
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Connexion...
+              </>
+            ) : 'Entrer'}
           </button>
         </form>
 
         {/* Footer */}
-        <p style={{ textAlign: 'center', marginTop: 24, fontSize: 11, color: '#3f3f46', letterSpacing: '0.02em' }}>
-          HttpOnly · Secure · SameSite=Strict
+        <p className="mt-5 flex items-center justify-center gap-1.5 text-[11px] text-text-muted">
+          <ShieldCheck className="h-3.5 w-3.5" />
+          Session HttpOnly · SameSite=Strict
         </p>
       </div>
     </div>

--- a/frontend/src/components/ReaderView.tsx
+++ b/frontend/src/components/ReaderView.tsx
@@ -14,16 +14,18 @@ import {
   AArrowUp,
   ThumbsUp,
   ThumbsDown,
+  PanelLeftClose,
+  PanelLeftOpen,
 } from 'lucide-react'
 import { useArticlesStore } from '../store/articles'
 import { useHighlightsStore } from '../store/highlights'
 import type { Highlight } from '../types'
-import { ScoreBar } from './ScoreBar'
 import { ReadTimeBadge } from './ReadTimeBadge'
 import { PaperView } from './PaperView'
 import { HighlightPopover } from './HighlightPopover'
 import { HighlightList } from './HighlightList'
 import { AskAIPanel } from './AskAIPanel'
+import { Eyebrow, IconButton, ScoreBadge } from './ui'
 
 // Heuristic: does this string look like HTML rather than plain text?
 // Checks for at least one block-level or common inline HTML tag.
@@ -320,139 +322,117 @@ export function ReaderView({ articleId, onBack, sidebarOpen, onToggleSidebar, on
       </div>
 
       {/* Toolbar */}
-      <div className="flex items-center justify-between px-3 py-2 border-b border-border-subtle bg-bg-surface flex-shrink-0">
+      <div className="flex items-center justify-between border-b border-border-subtle bg-bg-surface/95 px-3 py-2 flex-shrink-0">
         <div className="flex items-center gap-1">
           {/* Sidebar toggle (desktop only) */}
-          <button
+          <IconButton
             onClick={onToggleSidebar}
-            className="hidden lg:flex p-1.5 rounded-lg hover:bg-bg-hover transition-colors text-text-secondary hover:text-text-primary"
-            title={sidebarOpen ? 'Hide sidebar  [' : 'Show sidebar  ['}
-          >
-            {sidebarOpen ? <PanelLeftCloseIcon /> : <PanelLeftOpenIcon />}
-          </button>
+            icon={sidebarOpen ? PanelLeftClose : PanelLeftOpen}
+            label={sidebarOpen ? 'Masquer la sidebar  [' : 'Afficher la sidebar  ['}
+            className="hidden lg:inline-flex"
+          />
 
           {/* Back button (mobile) */}
           {onBack && (
-            <button
+            <IconButton
               onClick={onBack}
-              className="p-1.5 rounded-lg hover:bg-bg-hover transition-colors text-text-secondary hover:text-text-primary"
-              aria-label="Back"
-            >
-              <ArrowLeft className="w-4 h-4" />
-            </button>
+              icon={ArrowLeft}
+              label="Retour"
+            />
           )}
 
-          <div className="w-32">
-            <ScoreBar score={article.score} />
-          </div>
+          <ScoreBadge score={article.score} />
         </div>
 
         <div className="flex items-center gap-0.5">
           {/* Font size — hidden on small screens to avoid clipping feedback buttons */}
-          <button
+          <IconButton
             onClick={() => adjustFontSize(-1)}
             disabled={fontSize <= FONT_SIZE_MIN}
-            className="hidden sm:flex p-1.5 rounded-lg hover:bg-bg-hover transition-colors text-text-secondary hover:text-text-primary disabled:opacity-30"
-            title="Decrease font size"
-          >
-            <AArrowDown className="w-4 h-4" />
-          </button>
+            icon={AArrowDown}
+            label="Réduire la police"
+            className="hidden sm:inline-flex"
+          />
           <span className="hidden sm:inline text-xs text-text-muted tabular-nums w-6 text-center">{fontSize}</span>
-          <button
+          <IconButton
             onClick={() => adjustFontSize(1)}
             disabled={fontSize >= FONT_SIZE_MAX}
-            className="hidden sm:flex p-1.5 rounded-lg hover:bg-bg-hover transition-colors text-text-secondary hover:text-text-primary disabled:opacity-30"
-            title="Increase font size"
-          >
-            <AArrowUp className="w-4 h-4" />
-          </button>
+            icon={AArrowUp}
+            label="Agrandir la police"
+            className="hidden sm:inline-flex"
+          />
 
           <div className="hidden sm:block w-px h-4 bg-border-default mx-1" />
 
           {/* Read/unread toggle */}
-          <button
+          <IconButton
             onClick={() => article.read_at ? markUnread(article.id) : markRead(article.id)}
-            className={`p-1.5 rounded-lg hover:bg-bg-hover transition-colors ${
-              article.read_at ? 'text-accent-green' : 'text-text-secondary hover:text-text-primary'
-            }`}
-            title={article.read_at ? 'Mark unread' : 'Mark read'}
-          >
-            <RotateCcw className="w-4 h-4" />
-          </button>
+            icon={RotateCcw}
+            label={article.read_at ? 'Marquer non lu' : 'Marquer lu'}
+            active={Boolean(article.read_at)}
+            tone={article.read_at ? 'success' : 'default'}
+          />
 
           {/* Bookmark */}
-          <button
+          <IconButton
             onClick={() => toggleBookmark(article.id)}
-            className={`p-1.5 rounded-lg hover:bg-bg-hover transition-colors ${
-              article.bookmarked ? 'text-accent-blue' : 'text-text-secondary hover:text-text-primary'
-            }`}
-            title="Bookmark"
-          >
-            {article.bookmarked ? <BookmarkCheck className="w-4 h-4" /> : <Bookmark className="w-4 h-4" />}
-          </button>
+            icon={article.bookmarked ? BookmarkCheck : Bookmark}
+            label={article.bookmarked ? 'Retirer des favoris' : 'Ajouter aux favoris'}
+            active={article.bookmarked}
+          />
 
           {/* Feedback */}
           <div className="w-px h-4 bg-border-default mx-0.5" />
-          <button
+          <IconButton
             onClick={() => submitFeedback(article.id, article.user_feedback === 1 ? 0 : 1)}
-            className={`p-1.5 rounded-lg hover:bg-bg-hover transition-colors ${
-              article.user_feedback === 1 ? 'text-accent-green' : 'text-text-secondary hover:text-accent-green'
-            }`}
-            title={article.user_feedback === 1 ? 'Remove like' : 'Like — improve future scoring'}
-          >
-            <ThumbsUp className="w-4 h-4" />
-          </button>
-          <button
+            icon={ThumbsUp}
+            label={article.user_feedback === 1 ? 'Retirer le like' : 'Aimer pour améliorer le scoring'}
+            active={article.user_feedback === 1}
+            tone={article.user_feedback === 1 ? 'success' : 'default'}
+            className="hover:text-accent-green"
+          />
+          <IconButton
             onClick={() => submitFeedback(article.id, article.user_feedback === -1 ? 0 : -1)}
-            className={`p-1.5 rounded-lg hover:bg-bg-hover transition-colors ${
-              article.user_feedback === -1 ? 'text-red-400' : 'text-text-secondary hover:text-red-400'
-            }`}
-            title={article.user_feedback === -1 ? 'Remove dislike' : 'Dislike — improve future scoring'}
-          >
-            <ThumbsDown className="w-4 h-4" />
-          </button>
+            icon={ThumbsDown}
+            label={article.user_feedback === -1 ? 'Retirer le dislike' : 'Ne pas aimer pour améliorer le scoring'}
+            active={article.user_feedback === -1}
+            tone={article.user_feedback === -1 ? 'danger' : 'default'}
+            className="hover:text-accent-red"
+          />
 
           {/* Highlight list */}
           <div className="w-px h-4 bg-border-default mx-0.5" />
-          <button
+          <IconButton
             onClick={() => { setShowHighlightList((v) => !v); setShowAskPanel(false) }}
-            className={`p-1.5 rounded-lg hover:bg-bg-hover transition-colors ${
-              showHighlightList ? 'text-accent-yellow' : 'text-text-secondary hover:text-text-primary'
-            }`}
-            title={`Surlignages (${articleHighlights.length})`}
-          >
-            <Highlighter className="w-4 h-4" />
-          </button>
+            icon={Highlighter}
+            label={`Surlignages (${articleHighlights.length})`}
+            active={showHighlightList}
+            tone={showHighlightList ? 'warning' : 'default'}
+          />
 
           {/* Ask AI */}
-          <button
+          <IconButton
             onClick={() => { setShowAskPanel((v) => !v); setShowHighlightList(false) }}
-            className={`p-1.5 rounded-lg hover:bg-bg-hover transition-colors ${
-              showAskPanel ? 'text-accent-blue' : 'text-text-secondary hover:text-text-primary'
-            }`}
-            title="Poser une question à l'IA"
-          >
-            <Bot className="w-4 h-4" />
-          </button>
+            icon={Bot}
+            label="Poser une question à l'IA"
+            active={showAskPanel}
+          />
 
           {/* Copy link */}
-          <button
+          <IconButton
             onClick={copyLink}
-            className={`p-1.5 rounded-lg hover:bg-bg-hover transition-colors ${
-              copied ? 'text-accent-green' : 'text-text-secondary hover:text-text-primary'
-            }`}
-            title={copied ? 'Copied!' : 'Copy link'}
-          >
-            <Link className="w-4 h-4" />
-          </button>
+            icon={Link}
+            label={copied ? 'Lien copié' : 'Copier le lien'}
+            tone={copied ? 'success' : 'default'}
+          />
 
           {/* Open original */}
           <a
             href={article.url}
             target="_blank"
             rel="noopener noreferrer"
-            className="p-1.5 rounded-lg hover:bg-bg-hover transition-colors text-text-secondary hover:text-text-primary"
-            title="Open original"
+            className="inline-flex h-8 w-8 items-center justify-center rounded-md text-text-muted transition-colors hover:bg-bg-hover hover:text-text-primary"
+            title="Ouvrir l'original"
           >
             <ExternalLink className="w-4 h-4" />
           </a>
@@ -481,13 +461,13 @@ export function ReaderView({ articleId, onBack, sidebarOpen, onToggleSidebar, on
             className="flex-1 overflow-y-auto min-h-0"
             onScroll={handleScroll}
           >
-          <article className="max-w-2xl mx-auto px-5 py-8 pb-20">
+          <article className="mx-auto max-w-3xl px-5 py-9 pb-20 sm:px-8 lg:px-10">
 
             {/* Tags */}
             {article.tags.length > 0 && (
               <div className="flex flex-wrap gap-1.5 mb-4">
                 {article.tags.map(tag => (
-                  <span key={tag} className="px-2 py-0.5 bg-bg-elevated rounded-full text-xs text-text-muted font-medium">
+                  <span key={tag} className="rounded-md bg-bg-elevated/80 px-2 py-1 text-xs font-medium text-text-muted">
                     {tag}
                   </span>
                 ))}
@@ -495,12 +475,12 @@ export function ReaderView({ articleId, onBack, sidebarOpen, onToggleSidebar, on
             )}
 
             {/* Title */}
-            <h1 className="text-2xl font-bold leading-tight text-text-primary mb-3">
+            <h1 className="mb-4 max-w-[44rem] text-3xl font-semibold leading-tight text-text-primary sm:text-4xl">
               {article.title}
             </h1>
 
             {/* Meta */}
-            <div className="flex flex-wrap items-center gap-1.5 text-sm text-text-muted mb-5 pb-5 border-b border-border-subtle">
+            <div className="mb-6 flex flex-wrap items-center gap-2 border-b border-border-subtle pb-5 text-sm text-text-muted">
               {article.author && (
                 <span className="font-medium text-text-secondary">{article.author}</span>
               )}
@@ -519,20 +499,21 @@ export function ReaderView({ articleId, onBack, sidebarOpen, onToggleSidebar, on
 
             {/* AI Summary */}
             {article.summary_bullets.length > 0 && (
-              <div className="mb-6 p-4 bg-bg-surface rounded-xl border border-border-subtle">
-                <p className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-2.5">
-                  AI Summary
-                </p>
-                <ul className="space-y-1.5">
+              <div className="mb-7 rounded-md bg-accent-blue/8 p-4 sm:p-5">
+                <div className="mb-3 flex items-center justify-between gap-3">
+                  <Eyebrow>Résumé IA</Eyebrow>
+                  <ScoreBadge score={article.score} compact />
+                </div>
+                <ul className="space-y-2">
                   {article.summary_bullets.map((bullet, i) => (
-                    <li key={i} className="text-sm text-text-secondary leading-relaxed flex gap-2">
-                      <span className="text-accent-blue flex-shrink-0 mt-0.5">›</span>
+                    <li key={i} className="flex gap-2 text-sm leading-relaxed text-text-secondary">
+                      <span className="mt-[0.55em] h-1.5 w-1.5 flex-shrink-0 rounded-full bg-accent-blue" />
                       <span>{bullet}</span>
                     </li>
                   ))}
                 </ul>
                 {article.reason && (
-                  <p className="mt-3 pt-3 border-t border-border-subtle text-xs text-text-muted italic">
+                  <p className="mt-4 border-t border-accent-blue/18 pt-3 text-xs leading-relaxed text-text-muted">
                     {article.reason}
                   </p>
                 )}
@@ -541,7 +522,7 @@ export function ReaderView({ articleId, onBack, sidebarOpen, onToggleSidebar, on
 
             {/* Hero image */}
             {heroImage && (
-              <div className="mb-6 rounded-xl overflow-hidden">
+              <div className="mb-7 overflow-hidden rounded-md bg-bg-surface">
                 <img
                   src={heroImage}
                   alt=""
@@ -610,7 +591,7 @@ export function ReaderView({ articleId, onBack, sidebarOpen, onToggleSidebar, on
             {hasNext && onNext && scrollProgress >= 80 && (
               <button
                 onClick={onNext}
-                className="mt-6 w-full flex items-center justify-between px-4 py-3 rounded-xl bg-bg-surface border border-border-subtle hover:border-accent-blue/40 hover:bg-bg-elevated transition-all duration-200 group"
+                className="group mt-6 flex w-full items-center justify-between rounded-md bg-bg-surface px-4 py-3 transition-all duration-200 hover:bg-bg-elevated"
               >
                 <span className="text-xs text-text-muted group-hover:text-text-secondary transition-colors">
                   Article suivant
@@ -701,41 +682,16 @@ function Toolbar({
   return (
     <div className="flex items-center px-3 py-2 border-b border-border-subtle bg-bg-surface flex-shrink-0">
       <div className="flex items-center gap-1">
-        <button
+        <IconButton
           onClick={onToggleSidebar}
-          className="hidden lg:flex p-1.5 rounded-lg hover:bg-bg-hover transition-colors text-text-secondary"
-        >
-          {sidebarOpen ? <PanelLeftCloseIcon /> : <PanelLeftOpenIcon />}
-        </button>
+          icon={sidebarOpen ? PanelLeftClose : PanelLeftOpen}
+          label={sidebarOpen ? 'Masquer la sidebar' : 'Afficher la sidebar'}
+          className="hidden lg:inline-flex"
+        />
         {onBack && (
-          <button onClick={onBack} className="p-1.5 rounded-lg hover:bg-bg-hover transition-colors text-text-secondary">
-            <ArrowLeft className="w-4 h-4" />
-          </button>
+          <IconButton onClick={onBack} icon={ArrowLeft} label="Retour" />
         )}
       </div>
     </div>
-  )
-}
-
-// Inline SVG icons (avoids adding lucide-react panel icons that may not exist in older versions)
-function PanelLeftCloseIcon() {
-  return (
-    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
-      stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-      <rect width="18" height="18" x="3" y="3" rx="2"/>
-      <path d="M9 3v18"/>
-      <path d="m16 15-3-3 3-3"/>
-    </svg>
-  )
-}
-
-function PanelLeftOpenIcon() {
-  return (
-    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
-      stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-      <rect width="18" height="18" x="3" y="3" rx="2"/>
-      <path d="M9 3v18"/>
-      <path d="m14 9 3 3-3 3"/>
-    </svg>
   )
 }

--- a/frontend/src/components/StatsView.tsx
+++ b/frontend/src/components/StatsView.tsx
@@ -87,7 +87,7 @@ export function StatsView({ onClose }: StatsViewProps) {
       <div className="px-4 py-4 space-y-6">
 
         {/* Streak */}
-        <div className="flex items-center justify-center py-4 bg-bg-surface rounded-xl border border-border-subtle">
+        <div className="flex items-center justify-center rounded-md bg-bg-surface py-4">
           <div className="text-center">
             <div className="flex items-center justify-center gap-2 mb-1">
               <Flame className={`w-6 h-6 ${(s?.streak_days ?? 0) > 0 ? 'text-accent-yellow' : 'text-text-muted'}`} />
@@ -103,17 +103,17 @@ export function StatsView({ onClose }: StatsViewProps) {
 
         {/* Summary pills */}
         <div className="grid grid-cols-3 gap-2">
-          <div className="bg-bg-surface rounded-xl border border-border-subtle p-3 text-center">
+          <div className="rounded-md bg-bg-surface p-3 text-center">
             <BookOpen className="w-4 h-4 text-accent-blue mx-auto mb-1" />
             <div className="text-xl font-bold text-text-primary tabular-nums">{s?.total_read ?? 0}</div>
             <div className="text-xs text-text-muted">lus</div>
           </div>
-          <div className="bg-bg-surface rounded-xl border border-border-subtle p-3 text-center">
+          <div className="rounded-md bg-bg-surface p-3 text-center">
             <Bookmark className="w-4 h-4 text-accent-blue mx-auto mb-1" />
             <div className="text-xl font-bold text-text-primary tabular-nums">{s?.total_bookmarked ?? 0}</div>
             <div className="text-xs text-text-muted">bookmarks</div>
           </div>
-          <div className="bg-bg-surface rounded-xl border border-border-subtle p-3 text-center">
+          <div className="rounded-md bg-bg-surface p-3 text-center">
             <Star className="w-4 h-4 text-accent-yellow mx-auto mb-1" />
             <div className="text-xl font-bold text-text-primary tabular-nums">
               {s?.avg_score_read != null ? s.avg_score_read.toFixed(1) : '—'}
@@ -124,7 +124,7 @@ export function StatsView({ onClose }: StatsViewProps) {
 
         {/* Highlights count */}
         {(s?.total_highlights ?? 0) > 0 && (
-          <div className="flex items-center justify-between bg-bg-surface rounded-xl border border-border-subtle px-4 py-3">
+          <div className="flex items-center justify-between rounded-md bg-bg-surface px-4 py-3">
             <span className="text-xs text-text-secondary">Surlignages enregistrés</span>
             <span className="text-sm font-semibold text-accent-yellow">{s?.total_highlights}</span>
           </div>
@@ -133,7 +133,7 @@ export function StatsView({ onClose }: StatsViewProps) {
         {/* 7-day bar chart */}
         <div>
           <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-3">7 derniers jours</h3>
-          <div className="bg-bg-surface rounded-xl border border-border-subtle p-4">
+          <div className="rounded-md bg-bg-surface p-4">
             <div className="flex items-end justify-between gap-1.5 h-20">
               {last7.map((day) => (
                 <div key={day.date} className="flex flex-col items-center flex-1 gap-1">
@@ -158,7 +158,7 @@ export function StatsView({ onClose }: StatsViewProps) {
         {topTags.length > 0 && (
           <div>
             <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-3">Top tags lus</h3>
-            <div className="bg-bg-surface rounded-xl border border-border-subtle p-4">
+            <div className="rounded-md bg-bg-surface p-4">
               <div className="flex flex-wrap gap-2">
                 {topTags.map((t, i) => (
                   <span
@@ -178,7 +178,7 @@ export function StatsView({ onClose }: StatsViewProps) {
         {catEntries.length > 0 && (
           <div>
             <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-3">Par catégorie</h3>
-            <div className="bg-bg-surface rounded-xl border border-border-subtle p-4 space-y-2.5">
+            <div className="space-y-2.5 rounded-md bg-bg-surface p-4">
               {catEntries.map(([cat, count]) => (
                 <div key={cat} className="flex items-center gap-3">
                   <span className="text-xs text-text-secondary w-24 flex-shrink-0 truncate">{cat}</span>

--- a/frontend/src/components/briefing/BriefingArchive.tsx
+++ b/frontend/src/components/briefing/BriefingArchive.tsx
@@ -86,7 +86,7 @@ function DetailPane({
   if (selectedId === null) {
     return (
       <div className="flex h-full min-h-[60vh] flex-col items-center justify-center text-center">
-        <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-md border border-border-default bg-bg-surface text-accent-blue">
+        <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-md bg-bg-surface text-accent-blue">
           <Sparkles className="h-4 w-4" />
         </div>
         <p className="text-xs leading-relaxed text-text-muted">

--- a/frontend/src/components/briefing/BriefingHero.tsx
+++ b/frontend/src/components/briefing/BriefingHero.tsx
@@ -1,9 +1,10 @@
-import { CalendarDays, FileText, Layers3, Star } from 'lucide-react'
+import { CalendarDays, FileText, Layers3, Sparkles, Star } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { format } from 'date-fns'
 import { fr } from 'date-fns/locale'
 import type { BriefingContent } from '../../types'
 import { totalMinutes } from './format'
+import { Eyebrow } from '../ui'
 
 interface Props {
   content: BriefingContent
@@ -23,7 +24,7 @@ function Metric({
   accent?: boolean
 }) {
   return (
-    <div className="flex min-w-0 items-center gap-2 rounded-md border border-border-subtle bg-bg-surface px-3 py-2">
+    <div className="flex min-w-0 items-center gap-2 rounded-md bg-bg-elevated/55 px-3 py-2">
       <Icon className={`h-4 w-4 flex-shrink-0 ${accent ? 'text-accent-blue' : 'text-text-muted'}`} />
       <span className="min-w-0">
         <span className={`block text-sm font-semibold tabular-nums ${accent ? 'text-accent-blue' : 'text-text-primary'}`}>
@@ -46,9 +47,9 @@ export function BriefingHero({ content, generatedAt, articleCount }: Props) {
   const minutes = totalMinutes(picks)
 
   return (
-    <header className="briefing-rise">
+    <header className="briefing-rise rounded-md bg-bg-surface/70 p-5 sm:p-6">
       <div className="border-b border-border-subtle pb-5">
-        <div className="mb-2 flex flex-wrap items-center gap-2 text-xs text-text-muted">
+        <div className="mb-3 flex flex-wrap items-center gap-2 text-xs text-text-muted">
           <span className="inline-flex items-center gap-1.5 capitalize">
             <CalendarDays className="h-3.5 w-3.5" />
             {dateline}
@@ -56,14 +57,20 @@ export function BriefingHero({ content, generatedAt, articleCount }: Props) {
           <span className="text-border-default">·</span>
           <span>généré à {stamp}</span>
         </div>
-        <h1 className="text-3xl font-semibold leading-tight text-text-primary sm:text-4xl">
-          Le Briefing
-        </h1>
+        <Eyebrow className="mb-2">L'IA a lu le flux pour toi</Eyebrow>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+          <h1 className="max-w-2xl text-3xl font-semibold leading-tight text-text-primary sm:text-4xl">
+            Le Briefing du jour
+          </h1>
+          <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-md bg-accent-blue/12 text-accent-blue">
+            <Sparkles className="h-5 w-5" />
+          </div>
+        </div>
       </div>
 
       <div className="mt-5 grid gap-4 lg:grid-cols-[minmax(0,1fr)_280px]">
         {content.intro && (
-          <p className="reader-content text-[18px] leading-relaxed text-text-secondary sm:text-[19px]">
+          <p className="reader-content max-w-2xl text-[18px] leading-relaxed text-text-secondary sm:text-[19px]">
             {content.intro}
           </p>
         )}

--- a/frontend/src/components/briefing/BriefingSection.tsx
+++ b/frontend/src/components/briefing/BriefingSection.tsx
@@ -1,6 +1,7 @@
 import { ArrowUpRight, Check, Hash, Lightbulb } from 'lucide-react'
 import type { BriefingArticle, BriefingSection as Section } from '../../types'
-import { fmtScore, scoreColor, topTags } from './format'
+import { topTags } from './format'
+import { ScoreBadge } from '../ui'
 
 interface Props {
   section: Section
@@ -15,7 +16,7 @@ export function BriefingSection({ section, articles, index, onOpen }: Props) {
 
   return (
     <section
-      className="briefing-rise rounded-md border border-border-subtle bg-bg-surface"
+      className="briefing-rise rounded-md bg-bg-surface/80"
       style={{ animationDelay: `${130 + index * 60}ms` }}
     >
       <div className="border-b border-border-subtle px-4 py-4 sm:px-5">
@@ -40,7 +41,7 @@ export function BriefingSection({ section, articles, index, onOpen }: Props) {
                 {tags.map((t) => (
                   <span
                     key={t}
-                    className="inline-flex items-center gap-1 rounded bg-bg-elevated px-1.5 py-0.5 text-[10px] text-text-muted"
+                    className="inline-flex items-center gap-1 rounded bg-bg-elevated/80 px-1.5 py-0.5 text-[10px] text-text-muted"
                   >
                     <Hash className="h-2.5 w-2.5" />
                     {t}
@@ -58,7 +59,7 @@ export function BriefingSection({ section, articles, index, onOpen }: Props) {
         </p>
 
         {section.why_it_matters && (
-          <div className="mt-4 flex gap-3 rounded-md border border-[rgba(210,153,34,0.35)] bg-[rgba(210,153,34,0.06)] p-3">
+          <div className="mt-4 flex gap-3 rounded-md bg-[rgba(210,153,34,0.08)] p-3">
             <Lightbulb className="mt-0.5 h-4 w-4 flex-shrink-0 text-accent-yellow" />
             <div>
               <div className="text-xs font-semibold text-accent-yellow">Pourquoi ça compte</div>
@@ -74,13 +75,11 @@ export function BriefingSection({ section, articles, index, onOpen }: Props) {
                 <li key={a.id}>
                   <button
                     onClick={() => onOpen(a.id)}
-                    className={`group grid w-full grid-cols-[44px_minmax(0,1fr)_auto] items-start gap-3 py-3 text-left transition-colors hover:bg-bg-hover ${
+                    className={`group grid w-full grid-cols-[52px_minmax(0,1fr)_auto] items-start gap-3 rounded-md px-2 py-3 text-left transition-colors hover:bg-bg-hover ${
                       a.read_at ? 'opacity-55' : ''
                     }`}
                   >
-                    <span className={`mt-0.5 font-mono text-sm font-semibold tabular-nums ${scoreColor(a.score)}`}>
-                      {fmtScore(a.score)}
-                    </span>
+                    <ScoreBadge score={a.score} compact className="mt-0.5" />
                     <span className="min-w-0">
                       <span className="block text-sm font-medium leading-snug text-text-primary transition-colors group-hover:text-accent-blue">
                         {a.title}

--- a/frontend/src/components/briefing/BriefingSkeleton.tsx
+++ b/frontend/src/components/briefing/BriefingSkeleton.tsx
@@ -15,7 +15,7 @@ export function BriefingSkeleton() {
         {[0, 1].map(i => <div key={i} className="briefing-shimmer h-28 rounded-md" />)}
       </div>
       {[0, 1].map(i => (
-        <div key={i} className="space-y-3 rounded-md border border-border-subtle bg-bg-surface p-4">
+        <div key={i} className="space-y-3 rounded-md bg-bg-surface p-4">
           <div className="briefing-shimmer h-6 w-1/2 rounded-md" />
           <div className="briefing-shimmer h-16 w-full rounded-md" />
           <div className="briefing-shimmer h-12 w-full rounded-md" />

--- a/frontend/src/components/briefing/BriefingTimelineList.tsx
+++ b/frontend/src/components/briefing/BriefingTimelineList.tsx
@@ -62,7 +62,7 @@ export function BriefingTimelineList({
 
         {summariesStatus === 'ready' && summaries.length === 0 && (
           <div className="flex flex-col items-center justify-center px-4 py-16 text-center">
-            <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-md border border-border-default bg-bg-surface text-text-muted">
+            <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-md bg-bg-surface text-text-muted">
               <Archive className="h-4 w-4" />
             </div>
             <p className="text-xs leading-relaxed text-text-muted">

--- a/frontend/src/components/briefing/BriefingToolbar.tsx
+++ b/frontend/src/components/briefing/BriefingToolbar.tsx
@@ -1,4 +1,5 @@
-import { ArrowLeft, CalendarDays, RefreshCw, Sparkles } from 'lucide-react'
+import { ArrowLeft, CalendarDays, PanelLeftClose, PanelLeftOpen, RefreshCw, Sparkles } from 'lucide-react'
+import { IconButton } from '../ui'
 
 type Mode = 'live' | 'history'
 
@@ -25,25 +26,22 @@ export function BriefingToolbar({
   onToggleMode,
 }: Props) {
   return (
-    <div className="flex flex-shrink-0 items-center justify-between border-b border-border-subtle bg-bg-surface px-3 py-2">
+    <div className="flex flex-shrink-0 items-center justify-between border-b border-border-subtle bg-bg-surface/95 px-3 py-2">
       <div className="flex items-center gap-1">
         {onToggleSidebar && (
-          <button
+          <IconButton
             onClick={onToggleSidebar}
-            className="hidden p-1.5 rounded-lg text-text-secondary transition-colors hover:bg-bg-hover hover:text-text-primary lg:flex"
-            title={sidebarOpen ? 'Hide sidebar  [' : 'Show sidebar  ['}
-          >
-            {sidebarOpen ? <PanelLeftCloseIcon /> : <PanelLeftOpenIcon />}
-          </button>
+            icon={sidebarOpen ? PanelLeftClose : PanelLeftOpen}
+            label={sidebarOpen ? 'Masquer la sidebar  [' : 'Afficher la sidebar  ['}
+            className="hidden lg:inline-flex"
+          />
         )}
         {onBack && (
-          <button
+          <IconButton
             onClick={onBack}
-            className="p-1.5 rounded-lg text-text-secondary transition-colors hover:bg-bg-hover hover:text-text-primary"
-            aria-label="Retour aux articles"
-          >
-            <ArrowLeft className="h-4 w-4" />
-          </button>
+            icon={ArrowLeft}
+            label="Retour aux articles"
+          />
         )}
         <span className="ml-1 flex items-center gap-1.5 text-sm font-semibold text-text-primary">
           <Sparkles className="h-3.5 w-3.5 text-accent-blue" />
@@ -76,28 +74,5 @@ export function BriefingToolbar({
         )}
       </div>
     </div>
-  )
-}
-
-// Mirrors the inline panel icons used by ReaderView's toolbar for visual consistency.
-function PanelLeftCloseIcon() {
-  return (
-    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
-      stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-      <rect width="18" height="18" x="3" y="3" rx="2"/>
-      <path d="M9 3v18"/>
-      <path d="m16 15-3-3 3-3"/>
-    </svg>
-  )
-}
-
-function PanelLeftOpenIcon() {
-  return (
-    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
-      stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-      <rect width="18" height="18" x="3" y="3" rx="2"/>
-      <path d="M9 3v18"/>
-      <path d="m14 9 3 3-3 3"/>
-    </svg>
   )
 }

--- a/frontend/src/components/briefing/BriefingView.tsx
+++ b/frontend/src/components/briefing/BriefingView.tsx
@@ -74,7 +74,7 @@ export function BriefingView({ onOpen, sidebarOpen, onToggleSidebar, onBack, mod
 function EmptyState({ status, onGenerate }: { status: 'empty' | 'error'; onGenerate: () => void }) {
   return (
     <div className="mx-auto flex max-w-sm flex-col items-center justify-center py-24 text-center">
-      <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-md border border-border-default bg-bg-surface text-accent-blue">
+      <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-md bg-bg-surface text-accent-blue">
         <Sparkles className="h-5 w-5" />
       </div>
       <h2 className="text-base font-semibold text-text-primary">

--- a/frontend/src/components/briefing/TopPicks.tsx
+++ b/frontend/src/components/briefing/TopPicks.tsx
@@ -1,6 +1,6 @@
 import { ArrowUpRight, Clock, Star } from 'lucide-react'
 import type { BriefingArticle } from '../../types'
-import { fmtScore, scoreColor } from './format'
+import { ScoreBadge } from '../ui'
 
 interface Props {
   ids: number[]
@@ -29,18 +29,17 @@ export function TopPicks({ ids, articles, onOpen }: Props) {
             <li key={a.id}>
               <button
                 onClick={() => onOpen(a.id)}
-                className={`group flex h-full w-full items-start gap-3 rounded-md border border-border-subtle bg-bg-surface p-3 text-left transition-colors hover:border-border-default hover:bg-bg-hover ${
+                className={`group flex h-full w-full items-start gap-3 rounded-md bg-bg-surface/80 p-3.5 text-left transition-colors hover:bg-bg-hover ${
                   a.read_at ? 'opacity-55' : ''
                 }`}
               >
-                <span className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md bg-bg-elevated font-mono text-xs font-semibold tabular-nums text-text-secondary">
+                <span className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-md bg-bg-elevated font-mono text-xs font-semibold tabular-nums text-text-secondary">
                   {String(i + 1).padStart(2, '0')}
                 </span>
 
                 <span className="min-w-0 flex-1">
                   <span className="mb-1.5 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-text-muted">
-                    <span className={`font-semibold ${scoreColor(a.score)}`}>{fmtScore(a.score)}</span>
-                    <span className="text-border-default">·</span>
+                    <ScoreBadge score={a.score} compact />
                     <span className="max-w-full truncate">{a.feed_name}</span>
                     {a.reading_time ? (
                       <>
@@ -67,7 +66,7 @@ export function TopPicks({ ids, articles, onOpen }: Props) {
                       {a.tags.slice(0, 4).map((t) => (
                         <span
                           key={t}
-                          className="rounded bg-bg-elevated px-1.5 py-0.5 text-[10px] text-text-muted before:mr-px before:content-['#']"
+                          className="rounded bg-bg-elevated/80 px-1.5 py-0.5 text-[10px] text-text-muted"
                         >
                           {t}
                         </span>

--- a/frontend/src/components/ui.tsx
+++ b/frontend/src/components/ui.tsx
@@ -1,0 +1,146 @@
+import type { ButtonHTMLAttributes, ReactNode } from 'react'
+import type { LucideIcon } from 'lucide-react'
+
+type Tone = 'default' | 'active' | 'success' | 'warning' | 'danger'
+
+function toneClass(tone: Tone) {
+  switch (tone) {
+    case 'active':
+      return 'border-transparent bg-accent-blue/12 text-accent-blue'
+    case 'success':
+      return 'border-transparent bg-accent-green/12 text-accent-green'
+    case 'warning':
+      return 'border-transparent bg-accent-yellow/12 text-accent-yellow'
+    case 'danger':
+      return 'border-transparent bg-accent-red/12 text-accent-red'
+    default:
+      return 'border-transparent bg-transparent text-text-muted'
+  }
+}
+
+interface IconButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  icon: LucideIcon
+  label: string
+  tone?: Tone
+  active?: boolean
+}
+
+export function IconButton({
+  icon: Icon,
+  label,
+  tone = 'default',
+  active = false,
+  className = '',
+  ...props
+}: IconButtonProps) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      className={`
+        inline-flex h-8 w-8 items-center justify-center rounded-md border
+        transition-colors duration-150
+        hover:border-transparent hover:bg-bg-hover hover:text-text-primary
+        disabled:pointer-events-none disabled:opacity-40
+        ${toneClass(active && tone === 'default' ? 'active' : tone)}
+        ${className}
+      `}
+      {...props}
+    >
+      <Icon className="h-4 w-4" />
+    </button>
+  )
+}
+
+interface ScoreBadgeProps {
+  score: number | null | undefined
+  compact?: boolean
+  className?: string
+}
+
+export function ScoreBadge({ score, compact = false, className = '' }: ScoreBadgeProps) {
+  if (score === null || score === undefined) {
+    return (
+      <span className={`inline-flex items-center rounded-md bg-bg-elevated px-2 py-1 font-mono text-xs text-text-muted ${className}`}>
+        --
+      </span>
+    )
+  }
+
+  const tone =
+    score >= 8 ? 'text-score-high bg-score-high/10'
+    : score >= 5 ? 'text-score-mid bg-score-mid/10'
+    : 'text-score-low bg-score-low/10'
+
+  return (
+    <span
+      className={`
+        inline-flex items-baseline justify-center rounded-md font-mono font-semibold tabular-nums
+        ${compact ? 'min-w-10 px-1.5 py-0.5 text-[11px]' : 'min-w-12 px-2 py-1 text-xs'}
+        ${tone}
+        ${className}
+      `}
+      title={`Score IA : ${score.toFixed(1)}/10`}
+    >
+      {score.toFixed(1)}
+    </span>
+  )
+}
+
+interface SegmentedControlProps<T extends string> {
+  value: T
+  options: Array<{ value: T; label: string; icon?: LucideIcon }>
+  onChange: (value: T) => void
+  className?: string
+}
+
+export function SegmentedControl<T extends string>({
+  value,
+  options,
+  onChange,
+  className = '',
+}: SegmentedControlProps<T>) {
+  return (
+    <div className={`inline-flex rounded-md bg-bg-elevated/70 p-0.5 ${className}`}>
+      {options.map(option => {
+        const Icon = option.icon
+        const active = option.value === value
+        return (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => onChange(option.value)}
+            className={`
+              inline-flex min-h-7 flex-1 items-center justify-center gap-1.5 rounded px-2 text-xs font-medium
+              transition-colors duration-150
+              ${active
+                ? 'bg-bg-surface text-text-primary shadow-sm'
+                : 'text-text-muted hover:text-text-primary'
+              }
+            `}
+          >
+            {Icon && <Icon className="h-3.5 w-3.5" />}
+            <span>{option.label}</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+export function Eyebrow({ children, className = '' }: { children: ReactNode; className?: string }) {
+  return (
+    <p className={`text-[11px] font-semibold uppercase tracking-[0.14em] text-text-muted ${className}`}>
+      {children}
+    </p>
+  )
+}
+
+export function Kbd({ children }: { children: ReactNode }) {
+  return (
+    <kbd className="rounded bg-bg-elevated px-1.5 py-0.5 font-mono text-[11px] text-text-secondary">
+      {children}
+    </kbd>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,23 +3,23 @@
 @tailwind utilities;
 
 :root {
-  /* Dark theme CSS variables */
-  --color-bg-base: #0E1117;
-  --color-bg-surface: #161B22;
-  --color-bg-elevated: #1E2430;
-  --color-bg-hover: #232B39;
-  --color-border-subtle: #1E2430;
-  --color-border-default: #2A3341;
-  --color-text-primary: #E6EDF3;
-  --color-text-secondary: #A0ADB8;
-  --color-text-muted: #6B7685;
-  --color-accent-blue: #4493F8;
-  --color-accent-green: #3FB950;
-  --color-accent-yellow: #D29922;
-  --color-accent-red: #F85149;
-  --color-score-high: #3FB950;
-  --color-score-mid: #D29922;
-  --color-score-low: #F85149;
+  /* Dark reader theme: low-glare surfaces with deliberate accents. */
+  --color-bg-base: #101211;
+  --color-bg-surface: #151817;
+  --color-bg-elevated: #1B201E;
+  --color-bg-hover: #222A26;
+  --color-border-subtle: rgba(232, 238, 226, 0.07);
+  --color-border-default: rgba(232, 238, 226, 0.13);
+  --color-text-primary: #EAEEE8;
+  --color-text-secondary: #B6BDB3;
+  --color-text-muted: #818B82;
+  --color-accent-blue: #8BB8FF;
+  --color-accent-green: #67D99A;
+  --color-accent-yellow: #E7BE68;
+  --color-accent-red: #FF6B6B;
+  --color-score-high: #67D99A;
+  --color-score-mid: #E7BE68;
+  --color-score-low: #FF6B6B;
 }
 
 /* Always use dark mode */
@@ -44,6 +44,27 @@ body,
   -moz-osx-font-smoothing: grayscale;
 }
 
+body {
+  background: var(--color-bg-base);
+}
+
+button,
+a,
+input,
+select,
+textarea {
+  -webkit-tap-highlight-color: transparent;
+}
+
+button:focus-visible,
+a:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid rgba(104, 168, 255, 0.65);
+  outline-offset: 2px;
+}
+
 /* Hide scrollbars utility */
 .scrollbar-hide {
   -ms-overflow-style: none;
@@ -57,6 +78,7 @@ body,
 .reader-content {
   font-family: 'Lora', Georgia, serif;
   color: var(--color-text-primary);
+  letter-spacing: 0;
 }
 
 /* Paragraphs */
@@ -128,7 +150,7 @@ body,
   color: var(--color-text-secondary);
   font-style: italic;
   margin: 1.75em 0;
-  background: var(--color-bg-surface);
+  background: rgba(104, 168, 255, 0.06);
   border-radius: 0 0.4rem 0.4rem 0;
 }
 .reader-content blockquote p { margin-bottom: 0; }
@@ -191,6 +213,17 @@ body,
   overflow-x: auto;
   display: block;
 }
+
+.reader-content mark {
+  border-radius: 0.2rem;
+  padding: 0.05em 0.12em;
+  color: inherit;
+}
+
+.reader-content mark.highlight-yellow { background: rgba(231, 185, 85, 0.32); }
+.reader-content mark.highlight-green { background: rgba(78, 213, 134, 0.25); }
+.reader-content mark.highlight-blue { background: rgba(104, 168, 255, 0.25); }
+.reader-content mark.highlight-purple { background: rgba(168, 132, 255, 0.25); }
 .reader-content th {
   background: var(--color-bg-elevated);
   color: var(--color-text-secondary);
@@ -249,6 +282,28 @@ body,
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
+}
+
+.line-clamp-3 {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.briefing-rise {
+  animation: briefing-rise 420ms ease both;
+}
+
+@keyframes briefing-rise {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 /* Smooth scroll */


### PR DESCRIPTION
## What changed

- Softened the dark reader palette to reduce the high-contrast feel.
- Added shared UI primitives for icon buttons, score badges, keyboard hints, and segmented controls.
- Removed noisy decorative borders from the main reader surfaces, article list, briefing, login, and stats views.
- Kept functional layout separators while making repeated controls and tags visually quieter.

## Why

The UI refactor created too many small bordered rectangles around controls and badges. On a very dark background those borders read as white boxes everywhere, making the app feel harsher and more fragmented than a reading tool should.

## Validation

- `npm run typecheck`
- `npm run build`
- `docker compose build --no-cache frontend`
- `docker compose up -d frontend web`
- `curl http://localhost/api/health` -> `{"status":"ok"}`

Note: because the app is a PWA, an existing browser session may need its service worker/cache cleared to pick up the new bundle immediately.