### PR TITLE
[codex] Harden ingestion scoring pipeline

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -162,13 +162,16 @@ All state lives in SQLite under the Docker volume mounted at `/data`.
 
 ```bash
 # Backup
-docker compose exec api sqlite3 /data/makhal.db ".backup /data/makhal.db.bak"
+docker compose exec api python -c "import sqlite3; src=sqlite3.connect('/data/makhal.db'); dst=sqlite3.connect('/data/makhal.db.bak'); src.backup(dst); dst.close(); src.close()"
 docker compose cp api:/data/makhal.db.bak ./makhal.db.bak
 
 # Restore
 docker compose cp ./makhal.db.bak api:/data/makhal.db
 docker compose restart api
 ```
+
+The `api` image is based on `python:3.12-slim`; use Python's `sqlite3` module
+unless the image is explicitly changed to install the `sqlite3` CLI.
 
 For production, use the same commands with `-f docker-compose.yml -f docker-compose.npm.yml`.
 
@@ -185,7 +188,7 @@ docker compose up -d api
 To invalidate all active sessions:
 
 ```bash
-docker compose exec api sqlite3 /data/makhal.db "DELETE FROM auth_sessions;"
+docker compose exec api python -c "import sqlite3; db=sqlite3.connect('/data/makhal.db'); db.execute('DELETE FROM auth_sessions'); db.commit(); db.close()"
 ```
 
 ---

--- a/backend/api/database.py
+++ b/backend/api/database.py
@@ -77,9 +77,17 @@ class Article(Base):
     title_fingerprint = Column(String(16), nullable=True, index=True)
     user_feedback = Column(Integer, nullable=True)  # 1=like, -1=dislike, NULL=no feedback
     reading_time = Column(Integer, nullable=True)   # minutes, computed from word count
+    scoring_status = Column(String(16), default="queued", nullable=False)
+    score_attempts = Column(Integer, default=0, nullable=False)
+    next_score_attempt_at = Column(DateTime, nullable=True)
+    score_last_error = Column(Text, nullable=True)
+    score_locked_at = Column(DateTime, nullable=True)
+    scored_at = Column(DateTime, nullable=True)
 
     __table_args__ = (
         Index("ix_articles_title_fp_created", "title_fingerprint", "created_at"),
+        Index("ix_articles_scoring_queue", "scoring_status", "next_score_attempt_at", "created_at"),
+        Index("ix_articles_feed_created", "feed_id", "created_at"),
     )
 
 
@@ -176,10 +184,22 @@ def init_db():
         "ALTER TABLE articles ADD COLUMN user_feedback INTEGER",
         "ALTER TABLE articles ADD COLUMN reading_time INTEGER",
         "ALTER TABLE articles ADD COLUMN score_details_json TEXT NOT NULL DEFAULT '{}'",
+        "ALTER TABLE articles ADD COLUMN scoring_status VARCHAR(16) NOT NULL DEFAULT 'queued'",
+        "ALTER TABLE articles ADD COLUMN score_attempts INTEGER NOT NULL DEFAULT 0",
+        "ALTER TABLE articles ADD COLUMN next_score_attempt_at DATETIME",
+        "ALTER TABLE articles ADD COLUMN score_last_error TEXT",
+        "ALTER TABLE articles ADD COLUMN score_locked_at DATETIME",
+        "ALTER TABLE articles ADD COLUMN scored_at DATETIME",
+        "UPDATE articles SET scoring_status = 'queued' WHERE scoring_status IS NULL",
+        "UPDATE articles SET scoring_status = 'queued' WHERE score IS NULL AND scoring_status = 'done'",
+        "UPDATE articles SET scoring_status = 'done' WHERE score IS NOT NULL AND scoring_status IN ('queued', 'processing', 'retry')",
+        "UPDATE articles SET score_attempts = 0 WHERE score_attempts IS NULL",
         "CREATE TABLE IF NOT EXISTS highlights (id INTEGER PRIMARY KEY AUTOINCREMENT, article_id INTEGER NOT NULL REFERENCES articles(id) ON DELETE CASCADE, selected_text TEXT NOT NULL, prefix_context TEXT NOT NULL DEFAULT '', suffix_context TEXT NOT NULL DEFAULT '', color VARCHAR(16) NOT NULL DEFAULT 'yellow', note TEXT, created_at DATETIME NOT NULL)",
         "CREATE INDEX IF NOT EXISTS ix_highlights_article_id ON highlights(article_id)",
         "CREATE TABLE IF NOT EXISTS briefings (id INTEGER PRIMARY KEY AUTOINCREMENT, generated_at DATETIME NOT NULL, window_start DATETIME NOT NULL, window_end DATETIME NOT NULL, model_used VARCHAR, article_count INTEGER NOT NULL DEFAULT 0, content_json TEXT NOT NULL DEFAULT '{}')",
         "CREATE INDEX IF NOT EXISTS ix_briefings_generated_at ON briefings(generated_at)",
+        "CREATE INDEX IF NOT EXISTS ix_articles_scoring_queue ON articles(scoring_status, next_score_attempt_at, created_at)",
+        "CREATE INDEX IF NOT EXISTS ix_articles_feed_created ON articles(feed_id, created_at)",
     ]
     with engine.connect() as conn:
         for stmt in _migrations:

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -15,7 +15,7 @@ from fastapi import Depends, FastAPI, File, Header, HTTPException, Query, Reques
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
-from sqlalchemy import func, or_
+from sqlalchemy import and_, func, or_
 from sqlalchemy.orm import Session
 
 from auth import (
@@ -49,6 +49,9 @@ from models import (
     HighlightOut,
     HighlightUpdate,
     InternalArticleCreate,
+    InternalFeedFetched,
+    InternalScoreFailure,
+    InternalScoringClaimRequest,
     InternalScoreUpdate,
     StatsOut,
     TagFrequency,
@@ -57,6 +60,10 @@ from models import (
 API_SECRET = os.getenv("API_SECRET", "changeme")
 MAX_ARTICLES_PER_FEED = int(os.getenv("MAX_ARTICLES_PER_FEED", "200"))
 ARTICLE_RETENTION_DAYS = int(os.getenv("ARTICLE_RETENTION_DAYS", "90"))
+SCORING_MAX_ATTEMPTS = int(os.getenv("SCORING_MAX_ATTEMPTS", "5"))
+SCORING_LOCK_TIMEOUT_MINUTES = int(os.getenv("SCORING_LOCK_TIMEOUT_MINUTES", "20"))
+SCORING_RETRY_BASE_MINUTES = int(os.getenv("SCORING_RETRY_BASE_MINUTES", "5"))
+SCORING_RETRY_MAX_MINUTES = int(os.getenv("SCORING_RETRY_MAX_MINUTES", "360"))
 
 # LLM config (shared with scorer service)
 OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY", "")
@@ -330,7 +337,7 @@ class LoginRequest(BaseModel):
 
 
 @app.post("/auth/login")
-async def login(body: LoginRequest, request: Request, response: Response):
+def login(body: LoginRequest, request: Request, response: Response):
     ip = _client_ip(request)
     _check_rate_limit(ip)
 
@@ -348,7 +355,7 @@ async def login(body: LoginRequest, request: Request, response: Response):
 
 
 @app.post("/auth/logout")
-async def logout(request: Request, response: Response):
+def logout(request: Request, response: Response):
     token = request.cookies.get(COOKIE_NAME)
     if token:
         delete_session(token)
@@ -357,7 +364,7 @@ async def logout(request: Request, response: Response):
 
 
 @app.get("/auth/status")
-async def auth_status(request: Request):
+def auth_status(request: Request):
     from auth import validate_session
     token = request.cookies.get(COOKIE_NAME)
     if not token or not validate_session(token):
@@ -471,6 +478,10 @@ def _row_to_list_item(row) -> ArticleListItem:
         feed_category=feed_category or "",
         user_feedback=article.user_feedback,
         reading_time=article.reading_time,
+        scoring_status=article.scoring_status or ("done" if article.score is not None else "queued"),
+        score_attempts=article.score_attempts or 0,
+        next_score_attempt_at=article.next_score_attempt_at,
+        scored_at=article.scored_at,
     )
 
 
@@ -794,7 +805,7 @@ async def _broadcast_briefing(briefing: "Briefing"):
 
 
 @app.get("/api/internal/feeds")
-async def internal_list_feeds(
+def internal_list_feeds(
     x_internal_secret: Optional[str] = Header(None),
     db: Session = Depends(get_db),
 ):
@@ -814,7 +825,7 @@ async def internal_list_feeds(
 
 
 @app.get("/api/internal/feedback-examples")
-async def internal_feedback_examples(
+def internal_feedback_examples(
     x_internal_secret: Optional[str] = Header(None),
     db: Session = Depends(get_db),
 ):
@@ -889,7 +900,7 @@ async def internal_feedback_examples(
 
 
 @app.get("/api/internal/articles/exists")
-async def internal_article_exists(
+def internal_article_exists(
     url: str = Query(...),
     x_internal_secret: Optional[str] = Header(None),
     db: Session = Depends(get_db),
@@ -900,8 +911,32 @@ async def internal_article_exists(
     return {"exists": exists}
 
 
+@app.post("/api/internal/feeds/{feed_id}/fetched")
+def internal_mark_feed_fetched(
+    feed_id: int,
+    fetched: InternalFeedFetched,
+    x_internal_secret: Optional[str] = Header(None),
+    db: Session = Depends(get_db),
+):
+    if x_internal_secret != API_SECRET:
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+    feed = db.query(Feed).filter(Feed.id == feed_id).first()
+    if not feed:
+        raise HTTPException(status_code=404, detail="Feed not found")
+
+    feed.last_fetched = fetched.fetched_at or datetime.now(timezone.utc)
+    db.commit()
+    return {
+        "status": "ok",
+        "feed_id": feed.id,
+        "last_fetched": feed.last_fetched.isoformat() if feed.last_fetched else None,
+        "entry_count": fetched.entry_count,
+    }
+
+
 @app.post("/api/internal/articles")
-async def internal_create_article(
+def internal_create_article(
     article_data: InternalArticleCreate,
     x_internal_secret: Optional[str] = Header(None),
     db: Session = Depends(get_db),
@@ -944,11 +979,181 @@ async def internal_create_article(
         created_at=datetime.now(timezone.utc),
         title_fingerprint=fp,
         reading_time=article_data.reading_time,
+        scoring_status="queued",
+        score_attempts=0,
     )
     db.add(article)
     db.commit()
     db.refresh(article)
-    return {"id": article.id, "created": True}
+    return {
+        "id": article.id,
+        "created": True,
+        "scoring_status": article.scoring_status,
+        "scoring_attempts": article.score_attempts,
+        "scoring_next_retry_at": article.next_score_attempt_at.isoformat() if article.next_score_attempt_at else None,
+    }
+
+
+def _score_retry_delay(attempts: int) -> timedelta:
+    attempts = max(1, attempts)
+    minutes = min(
+        SCORING_RETRY_BASE_MINUTES * (2 ** (attempts - 1)),
+        SCORING_RETRY_MAX_MINUTES,
+    )
+    return timedelta(minutes=minutes)
+
+
+def _score_claim_payload(article: Article) -> dict:
+    return {
+        "article_id": article.id,
+        "id": article.id,
+        "title": article.title,
+        "content_text": article.content_text or "",
+        "rss_summary": "",
+        "status": article.scoring_status,
+        "attempts": article.score_attempts or 0,
+        "next_retry_at": article.next_score_attempt_at.isoformat() if article.next_score_attempt_at else None,
+        "created_at": article.created_at.isoformat() if article.created_at else None,
+    }
+
+
+@app.post("/api/internal/scoring/claim")
+def internal_claim_scoring_batch(
+    claim: InternalScoringClaimRequest,
+    x_internal_secret: Optional[str] = Header(None),
+    db: Session = Depends(get_db),
+):
+    if x_internal_secret != API_SECRET:
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+    now = datetime.now(timezone.utc)
+    stale_lock_cutoff = now - timedelta(minutes=SCORING_LOCK_TIMEOUT_MINUTES)
+    eligible = or_(
+        Article.scoring_status.is_(None),
+        Article.scoring_status.in_(("queued", "retry")),
+        and_(
+            Article.scoring_status == "processing",
+            Article.score_locked_at.isnot(None),
+            Article.score_locked_at < stale_lock_cutoff,
+        ),
+    )
+    due = or_(Article.next_score_attempt_at.is_(None), Article.next_score_attempt_at <= now)
+
+    articles = (
+        db.query(Article)
+        .filter(Article.score.is_(None), eligible, due)
+        .order_by(Article.score_attempts.asc(), Article.created_at.asc())
+        .limit(claim.limit)
+        .all()
+    )
+
+    for article in articles:
+        article.scoring_status = "processing"
+        article.score_attempts = (article.score_attempts or 0) + 1
+        article.score_locked_at = now
+        article.next_score_attempt_at = None
+        article.score_last_error = None
+
+    db.commit()
+    for article in articles:
+        db.refresh(article)
+
+    return {"items": [_score_claim_payload(article) for article in articles]}
+
+
+@app.post("/api/internal/articles/{article_id}/score-failed")
+def internal_score_article_failed(
+    article_id: int,
+    failure: InternalScoreFailure,
+    x_internal_secret: Optional[str] = Header(None),
+    db: Session = Depends(get_db),
+):
+    if x_internal_secret != API_SECRET:
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+    article = db.query(Article).filter(Article.id == article_id).first()
+    if not article:
+        raise HTTPException(status_code=404, detail="Article not found")
+
+    now = datetime.now(timezone.utc)
+    attempts = max(article.score_attempts or 1, 1)
+    article.score_last_error = failure.error or "Scoring failed"
+    article.score_locked_at = None
+
+    if attempts >= SCORING_MAX_ATTEMPTS:
+        article.scoring_status = "failed"
+        article.next_score_attempt_at = None
+    else:
+        article.scoring_status = "retry"
+        article.next_score_attempt_at = now + _score_retry_delay(attempts)
+
+    db.commit()
+    return {
+        "status": article.scoring_status,
+        "attempts": attempts,
+        "next_retry_at": article.next_score_attempt_at.isoformat() if article.next_score_attempt_at else None,
+        "max_attempts": SCORING_MAX_ATTEMPTS,
+    }
+
+
+@app.get("/api/internal/scoring/stats")
+def internal_scoring_stats(
+    x_internal_secret: Optional[str] = Header(None),
+    db: Session = Depends(get_db),
+):
+    if x_internal_secret != API_SECRET:
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+    status_rows = (
+        db.query(Article.scoring_status, func.count(Article.id))
+        .group_by(Article.scoring_status)
+        .all()
+    )
+    by_status = {(status or "queued"): count for status, count in status_rows}
+    unscored = db.query(Article).filter(Article.score.is_(None)).count()
+    ready = (
+        db.query(Article)
+        .filter(
+            Article.score.is_(None),
+            Article.scoring_status.in_(("queued", "retry")),
+            or_(Article.next_score_attempt_at.is_(None), Article.next_score_attempt_at <= datetime.now(timezone.utc)),
+        )
+        .count()
+    )
+    return {
+        "total": db.query(Article).count(),
+        "unscored": unscored,
+        "ready": ready,
+        "by_status": by_status,
+        "max_attempts": SCORING_MAX_ATTEMPTS,
+    }
+
+
+@app.post("/api/internal/scoring/requeue-failed")
+def internal_requeue_failed_scoring(
+    limit: int = Query(100, ge=1, le=1000),
+    x_internal_secret: Optional[str] = Header(None),
+    db: Session = Depends(get_db),
+):
+    if x_internal_secret != API_SECRET:
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+    articles = (
+        db.query(Article)
+        .filter(Article.score.is_(None), Article.scoring_status == "failed")
+        .order_by(Article.created_at.asc())
+        .limit(limit)
+        .all()
+    )
+    for article in articles:
+        article.scoring_status = "queued"
+        article.score_attempts = 0
+        article.next_score_attempt_at = None
+        article.score_last_error = None
+        article.score_locked_at = None
+
+    db.commit()
+    return {"status": "ok", "requeued": len(articles)}
 
 
 @app.delete("/api/admin/articles/broken")
@@ -1411,6 +1616,11 @@ async def internal_score_article(
     article.tags_json = json.dumps(score_data.tags)
     article.summary_bullets_json = json.dumps(score_data.summary_bullets)
     article.reason = score_data.reason
+    article.scoring_status = "done"
+    article.next_score_attempt_at = None
+    article.score_last_error = None
+    article.score_locked_at = None
+    article.scored_at = datetime.now(timezone.utc)
     db.commit()
     db.refresh(article)
 
@@ -1435,6 +1645,9 @@ async def internal_score_article(
         "feed_category": feed.category if feed else "",
         "user_feedback": article.user_feedback,
         "reading_time": article.reading_time,
+        "scoring_status": article.scoring_status,
+        "score_attempts": article.score_attempts,
+        "scored_at": article.scored_at.isoformat() if article.scored_at else None,
     }
     await _broadcast_new_article(article_dict)
 

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -45,6 +45,12 @@ class ArticleOut(BaseModel):
     created_at: datetime
     user_feedback: Optional[int] = None
     reading_time: Optional[int] = None
+    scoring_status: str = "queued"
+    score_attempts: int = 0
+    next_score_attempt_at: Optional[datetime] = None
+    score_last_error: Optional[str] = None
+    score_locked_at: Optional[datetime] = None
+    scored_at: Optional[datetime] = None
 
     # Computed fields
     tags: List[str] = []
@@ -94,6 +100,10 @@ class ArticleListItem(BaseModel):
     feed_category: str = ""
     user_feedback: Optional[int] = None
     reading_time: Optional[int] = None
+    scoring_status: str = "queued"
+    score_attempts: int = 0
+    next_score_attempt_at: Optional[datetime] = None
+    scored_at: Optional[datetime] = None
 
     # Computed fields
     tags: List[str] = []
@@ -182,6 +192,30 @@ class InternalScoreUpdate(BaseModel):
     summary_bullets: List[str] = []
     reason: Optional[str] = None
     score_details: Dict[str, Any] = {}
+
+
+class InternalScoringClaimRequest(BaseModel):
+    limit: int = 5
+
+    @field_validator("limit")
+    @classmethod
+    def validate_limit(cls, v: int) -> int:
+        return max(1, min(int(v), 50))
+
+
+class InternalScoreFailure(BaseModel):
+    error: str = ""
+
+    @field_validator("error")
+    @classmethod
+    def validate_error(cls, v: str) -> str:
+        return str(v or "").strip()[:2000]
+
+
+class InternalFeedFetched(BaseModel):
+    fetched_at: Optional[datetime] = None
+    entry_count: int = 0
+    status: str = "parsed"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/api/tests/test_pipeline_contracts.py
+++ b/backend/api/tests/test_pipeline_contracts.py
@@ -1,0 +1,181 @@
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+import main
+from database import Article, Base, Feed
+from models import InternalScoreFailure, InternalScoringClaimRequest, InternalScoreUpdate
+
+
+def _memory_session():
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+@pytest.mark.asyncio
+async def test_health_contract_stays_public_and_minimal():
+    assert await main.health() == {"status": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_internal_score_update_persists_and_broadcasts(monkeypatch):
+    db = _memory_session()
+    db.add(Feed(id=1, url="https://example.test/feed.xml", name="Feed", category="Infra"))
+    db.add(
+        Article(
+            id=10,
+            feed_id=1,
+            title="Queued article",
+            url="https://example.test/a",
+            content_text="body",
+            content_html="<p>body</p>",
+            created_at=datetime.now(timezone.utc),
+        )
+    )
+    db.commit()
+
+    broadcasts = []
+
+    async def fake_broadcast(payload):
+        broadcasts.append(payload)
+
+    monkeypatch.setattr(main, "_broadcast_new_article", fake_broadcast)
+
+    result = await main.internal_score_article(
+        10,
+        InternalScoreUpdate(
+            score=7.4,
+            tags=["ops"],
+            summary_bullets=["Useful detail"],
+            reason="Concrete operational value.",
+            score_details={"scoring_version": 3},
+        ),
+        x_internal_secret=main.API_SECRET,
+        db=db,
+    )
+
+    article = db.query(Article).filter(Article.id == 10).one()
+    assert result == {"status": "ok"}
+    assert article.score == 7.4
+    assert '"scoring_version": 3' in article.score_details_json
+    assert broadcasts[0]["id"] == 10
+    assert broadcasts[0]["score"] == 7.4
+    assert broadcasts[0]["score_details"] == {"scoring_version": 3}
+    assert article.scoring_status == "done"
+    assert article.scored_at is not None
+
+
+@pytest.mark.asyncio
+async def test_internal_scoring_claim_marks_articles_processing():
+    db = _memory_session()
+    db.add(Feed(id=1, url="https://example.test/feed.xml", name="Feed", category="Infra"))
+    db.add(
+        Article(
+            id=20,
+            feed_id=1,
+            title="Needs score",
+            url="https://example.test/needs-score",
+            content_text="body",
+            created_at=datetime.now(timezone.utc),
+            scoring_status="queued",
+            score_attempts=0,
+        )
+    )
+    db.commit()
+
+    result = main.internal_claim_scoring_batch(
+        InternalScoringClaimRequest(limit=1),
+        x_internal_secret=main.API_SECRET,
+        db=db,
+    )
+
+    article = db.query(Article).filter(Article.id == 20).one()
+    assert result["items"][0]["article_id"] == 20
+    assert result["items"][0]["attempts"] == 1
+    assert article.scoring_status == "processing"
+    assert article.score_attempts == 1
+    assert article.score_locked_at is not None
+
+
+@pytest.mark.asyncio
+async def test_internal_score_failure_schedules_retry_then_failed():
+    db = _memory_session()
+    db.add(Feed(id=1, url="https://example.test/feed.xml", name="Feed", category="Infra"))
+    db.add(
+        Article(
+            id=30,
+            feed_id=1,
+            title="Retry me",
+            url="https://example.test/retry-me",
+            content_text="body",
+            created_at=datetime.now(timezone.utc),
+            scoring_status="processing",
+            score_attempts=1,
+            score_locked_at=datetime.now(timezone.utc),
+        )
+    )
+    db.commit()
+
+    retry = main.internal_score_article_failed(
+        30,
+        InternalScoreFailure(error="LLM returned bad JSON"),
+        x_internal_secret=main.API_SECRET,
+        db=db,
+    )
+
+    article = db.query(Article).filter(Article.id == 30).one()
+    assert retry["status"] == "retry"
+    assert article.next_score_attempt_at is not None
+    assert article.score_locked_at is None
+    assert "bad JSON" in article.score_last_error
+
+    article.score_attempts = main.SCORING_MAX_ATTEMPTS
+    article.scoring_status = "processing"
+    article.score_locked_at = datetime.now(timezone.utc)
+    db.commit()
+
+    failed = main.internal_score_article_failed(
+        30,
+        InternalScoreFailure(error="still bad"),
+        x_internal_secret=main.API_SECRET,
+        db=db,
+    )
+
+    assert failed["status"] == "failed"
+    assert article.scoring_status == "failed"
+    assert article.next_score_attempt_at is None
+
+
+@pytest.mark.asyncio
+async def test_internal_requeue_failed_resets_retry_state():
+    db = _memory_session()
+    db.add(Feed(id=1, url="https://example.test/feed.xml", name="Feed", category="Infra"))
+    db.add(
+        Article(
+            id=40,
+            feed_id=1,
+            title="Failed article",
+            url="https://example.test/failed",
+            content_text="body",
+            created_at=datetime.now(timezone.utc),
+            scoring_status="failed",
+            score_attempts=main.SCORING_MAX_ATTEMPTS,
+            score_last_error="bad model",
+        )
+    )
+    db.commit()
+
+    result = main.internal_requeue_failed_scoring(
+        limit=10,
+        x_internal_secret=main.API_SECRET,
+        db=db,
+    )
+
+    article = db.query(Article).filter(Article.id == 40).one()
+    assert result == {"status": "ok", "requeued": 1}
+    assert article.scoring_status == "queued"
+    assert article.score_attempts == 0
+    assert article.score_last_error is None

--- a/backend/extractor/extractor.py
+++ b/backend/extractor/extractor.py
@@ -6,6 +6,7 @@ from typing import List, Optional, Tuple
 from urllib.parse import quote_plus, urlparse, urlunparse
 
 import httpx
+import bleach
 import trafilatura
 from bs4 import BeautifulSoup, Tag
 from fastapi import FastAPI
@@ -31,6 +32,86 @@ HEADERS = {
 }
 
 MIN_CONTENT_LENGTH = 300
+
+ALLOWED_HTML_TAGS = frozenset(
+    {
+        "a",
+        "abbr",
+        "article",
+        "aside",
+        "b",
+        "blockquote",
+        "br",
+        "caption",
+        "cite",
+        "code",
+        "dd",
+        "del",
+        "details",
+        "dfn",
+        "div",
+        "dl",
+        "dt",
+        "em",
+        "figcaption",
+        "figure",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "hr",
+        "i",
+        "img",
+        "ins",
+        "kbd",
+        "li",
+        "main",
+        "mark",
+        "ol",
+        "p",
+        "pre",
+        "q",
+        "s",
+        "samp",
+        "section",
+        "small",
+        "span",
+        "strong",
+        "sub",
+        "summary",
+        "sup",
+        "table",
+        "tbody",
+        "td",
+        "tfoot",
+        "th",
+        "thead",
+        "time",
+        "tr",
+        "u",
+        "ul",
+        "var",
+    }
+)
+ALLOWED_HTML_PROTOCOLS = frozenset({"http", "https", "mailto"})
+SAFE_LINK_TARGETS = frozenset({"_blank", "_self", "_parent", "_top"})
+SAFE_LINK_REL = ("noopener", "noreferrer")
+GLOBAL_HTML_ATTRS = frozenset({"class", "dir", "lang", "title"})
+TAG_HTML_ATTRS = {
+    "a": frozenset({"href", "rel", "target", "title"}),
+    "blockquote": frozenset({"cite"}),
+    "code": frozenset({"class"}),
+    "img": frozenset({"alt", "height", "loading", "src", "title", "width"}),
+    "pre": frozenset({"class"}),
+    "q": frozenset({"cite"}),
+    "td": frozenset({"colspan", "headers", "rowspan"}),
+    "th": frozenset({"colspan", "headers", "rowspan", "scope"}),
+    "time": frozenset({"datetime"}),
+}
+
+URL_ATTRS = frozenset({"cite", "href", "src"})
 
 ARXIV_ABS_RE = re.compile(
     r"arxiv\.org/abs/(?P<id>[0-9]{4}\.[0-9]+(v\d+)?|[a-z\-]+/\d{7})", re.I
@@ -203,7 +284,7 @@ def strip_html(text: str) -> str:
 
 def text_to_html(text: str) -> str:
     paragraphs = [p.strip() for p in text.split("\n\n") if p.strip()]
-    return "\n".join(f"<p>{p}</p>" for p in paragraphs)
+    return "\n".join(f"<p>{html_lib.escape(p)}</p>" for p in paragraphs)
 
 
 def html_to_text(html: str) -> str:
@@ -211,6 +292,60 @@ def html_to_text(html: str) -> str:
         return BeautifulSoup(html, "html.parser").get_text(separator="\n\n", strip=True)
     except Exception:
         return ""
+
+
+def is_safe_url_attr(attr: str, value: str) -> bool:
+    value = (value or "").strip()
+    if not value:
+        return False
+
+    parsed = urlparse(value)
+    if not parsed.scheme:
+        return True
+    if attr == "src":
+        return parsed.scheme.lower() in {"http", "https"}
+    return parsed.scheme.lower() in ALLOWED_HTML_PROTOCOLS
+
+
+def allow_article_attr(tag: str, attr: str, value: str) -> bool:
+    attr = attr.lower()
+    if attr.startswith("on") or attr == "style":
+        return False
+    if attr == "target" and value not in SAFE_LINK_TARGETS:
+        return False
+    if attr in URL_ATTRS and not is_safe_url_attr(attr, value):
+        return False
+    return attr in GLOBAL_HTML_ATTRS or attr in TAG_HTML_ATTRS.get(tag, frozenset())
+
+
+def sanitize_article_html(raw: str, base_url: str) -> str:
+    """Strip active/executable HTML while preserving normal article markup."""
+    try:
+        cleaner = bleach.Cleaner(
+            tags=ALLOWED_HTML_TAGS,
+            attributes=allow_article_attr,
+            protocols=ALLOWED_HTML_PROTOCOLS,
+            strip=True,
+            strip_comments=True,
+        )
+        cleaned = cleaner.clean(raw or "")
+        soup = BeautifulSoup(cleaned, "html.parser")
+
+        for link in soup.find_all("a"):
+            if not link.get("href"):
+                continue
+            raw_rel = link.get("rel") or []
+            rel = set(raw_rel.split()) if isinstance(raw_rel, str) else set(raw_rel)
+            rel.update(SAFE_LINK_REL)
+            link["rel"] = " ".join(sorted(rel))
+
+        for img in soup.find_all("img"):
+            if not img.get("src"):
+                img.decompose()
+
+        return str(soup)
+    except Exception:
+        return bleach.clean(raw or "", tags=[], strip=True, strip_comments=True)
 
 
 def clean_readability_html(raw: str, base_url: str) -> str:
@@ -237,11 +372,11 @@ def clean_readability_html(raw: str, base_url: str) -> str:
         # Unwrap outer readability div
         outer = soup.find("div", id=re.compile(r"readability"))
         if outer and isinstance(outer, Tag):
-            return outer.decode_contents()
+            return sanitize_article_html(outer.decode_contents(), base_url)
 
-        return str(soup)
+        return sanitize_article_html(str(soup), base_url)
     except Exception:
-        return raw
+        return sanitize_article_html(raw, base_url)
 
 
 def extract_images_from_html(
@@ -559,6 +694,7 @@ def extract_with_trafilatura(html: str, url: str) -> dict:
             output_format="html",
             favor_recall=True,
         ) or text_to_html(plain_text)
+        raw_html = clean_readability_html(raw_html, url)
 
         return {
             "title": clean_title(data.get("title")),
@@ -719,7 +855,7 @@ async def extract(req: ExtractRequest) -> ExtractResponse:
                 arxiv_data = extract_arxiv(html, req.url)
                 if arxiv_data.get("text"):
                     content_text = arxiv_data["text"]
-                    content_html = arxiv_data["raw_html"]
+                    content_html = sanitize_article_html(arxiv_data["raw_html"], req.url)
                     extracted_title = arxiv_data.get("title")
                     author = arxiv_data.get("author")
                     # Canonical: strip version suffix  (abs/2501.12345v2 → abs/2501.12345)
@@ -747,7 +883,7 @@ async def extract(req: ExtractRequest) -> ExtractResponse:
                 final_title = resolve_title(None, req.rss_title, abstract)
                 return ExtractResponse(
                     title=final_title,
-                    content_html=f"<p>{abstract}</p>",
+                    content_html=sanitize_article_html(text_to_html(abstract), req.url),
                     content_text=abstract,
                     images=[],
                     author=None,
@@ -767,7 +903,7 @@ async def extract(req: ExtractRequest) -> ExtractResponse:
                 reddit_data = extract_reddit_rss_context(req)
             if reddit_data.get("text"):
                 content_text = reddit_data["text"]
-                content_html = reddit_data["raw_html"]
+                content_html = sanitize_article_html(reddit_data["raw_html"], req.url)
                 extracted_title = reddit_data.get("title")
                 author = reddit_data.get("author")
                 final_title = resolve_title(extracted_title, req.rss_title, content_text)
@@ -890,6 +1026,9 @@ async def extract(req: ExtractRequest) -> ExtractResponse:
             extraction_failed = True
 
         final_title = resolve_title(extracted_title, req.rss_title, content_text)
+        content_html = (
+            sanitize_article_html(content_html, req.url) if content_html else None
+        )
 
         return ExtractResponse(
             title=final_title,

--- a/backend/extractor/requirements.txt
+++ b/backend/extractor/requirements.txt
@@ -4,5 +4,6 @@ httpx==0.27.0
 trafilatura==1.12.0
 readability-lxml==0.8.1
 beautifulsoup4==4.12.3
+bleach==6.2.0
 lxml==5.3.0
 pydantic==2.7.1

--- a/backend/extractor/tests/test_sanitization.py
+++ b/backend/extractor/tests/test_sanitization.py
@@ -1,0 +1,128 @@
+from pathlib import Path
+import asyncio
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import extractor
+from extractor import clean_readability_html, sanitize_article_html
+
+
+def test_sanitize_removes_scripts_handlers_styles_and_unsafe_protocols():
+    raw = """
+    <article onclick="steal()">
+      <h2>Useful heading</h2>
+      <p style="color:red">Hello <strong>reader</strong></p>
+      <script>alert(1)</script>
+      <img src="javascript:alert(1)" onerror="alert(1)" alt="bad">
+      <a href="javascript:alert(1)" target="_blank">bad link</a>
+      <form><input name="email"></form>
+      <iframe src="https://example.com/embed"></iframe>
+    </article>
+    """
+
+    cleaned = sanitize_article_html(raw, "https://example.com/posts/one")
+
+    assert "<script" not in cleaned
+    assert "onclick" not in cleaned
+    assert "onerror" not in cleaned
+    assert "style=" not in cleaned
+    assert "javascript:" not in cleaned
+    assert "<form" not in cleaned
+    assert "<iframe" not in cleaned
+    assert "<h2>Useful heading</h2>" in cleaned
+    assert "<strong>reader</strong>" in cleaned
+    assert "<img" not in cleaned
+
+
+def test_clean_readability_html_preserves_article_markup_and_secures_links():
+    raw = """
+    <div id="readability-page-1">
+      <h1>Article title</h1>
+      <p>Intro with <em>emphasis</em> and <code>code()</code>.</p>
+      <blockquote cite="/source">quoted text</blockquote>
+      <pre><code class="language-python">print("ok")</code></pre>
+      <table><thead><tr><th scope="col">Name</th></tr></thead><tbody><tr><td>Value</td></tr></tbody></table>
+      <a href="/posts/next" target="_blank" rel="nofollow">next</a>
+      <img src="/images/pic.jpg" alt="A picture" width="640" height="320">
+    </div>
+    """
+
+    cleaned = clean_readability_html(raw, "https://example.com/articles/current")
+
+    assert "<h1>Article title</h1>" in cleaned
+    assert "<blockquote cite=\"/source\">quoted text</blockquote>" in cleaned
+    assert "<pre><code class=\"language-python\">" in cleaned
+    assert "<table>" in cleaned
+    assert "href=\"https://example.com/posts/next\"" in cleaned
+    assert "target=\"_blank\"" in cleaned
+    assert "noopener" in cleaned
+    assert "noreferrer" in cleaned
+    assert "rel=\"nofollow noopener noreferrer\"" in cleaned
+    assert "src=\"https://example.com/images/pic.jpg\"" in cleaned
+
+
+def test_sanitize_keeps_safe_mailto_and_removes_unsafe_data_image():
+    raw = """
+    <p>
+      <a href="mailto:editor@example.com">email</a>
+      <img src="data:image/svg+xml,<svg onload=alert(1)>" alt="inline">
+    </p>
+    """
+
+    cleaned = sanitize_article_html(raw, "https://example.com")
+
+    assert "href=\"mailto:editor@example.com\"" in cleaned
+    assert "noopener" in cleaned
+    assert "noreferrer" in cleaned
+    assert "<img" not in cleaned
+    assert "data:image" not in cleaned
+
+
+def test_extract_sanitizes_rss_summary_fallback_before_response():
+    async def fake_fetch(*args, **kwargs):
+        return None
+
+    old_fetch_url = extractor.fetch_url
+    old_google_cache = extractor.try_google_cache
+    old_wayback = extractor.try_wayback_machine
+    extractor.fetch_url = fake_fetch
+    extractor.try_google_cache = fake_fetch
+    extractor.try_wayback_machine = fake_fetch
+    try:
+        summary = """
+        <p onclick="alert(1)">Useful summary text that is deliberately long enough
+        to pass the rich RSS fallback threshold and represent a newsletter body.
+        This paragraph contains article content worth preserving for the reader.</p>
+        <script>alert(1)</script>
+        <a href="javascript:alert(1)" target="_blank">bad</a>
+        <img src="/cover.jpg" alt="Cover" onerror="alert(1)">
+        """
+        response = asyncio.run(
+            extractor.extract(
+                extractor.ExtractRequest(
+                    url="https://example.com/post",
+                    rss_title="RSS title",
+                    rss_summary=summary,
+                )
+            )
+        )
+    finally:
+        extractor.fetch_url = old_fetch_url
+        extractor.try_google_cache = old_google_cache
+        extractor.try_wayback_machine = old_wayback
+
+    assert response.content_html is not None
+    assert "Useful summary text" in response.content_html
+    assert "<script" not in response.content_html
+    assert "onclick" not in response.content_html
+    assert "onerror" not in response.content_html
+    assert "javascript:" not in response.content_html
+    assert "src=\"/cover.jpg\"" in response.content_html
+
+
+if __name__ == "__main__":
+    test_sanitize_removes_scripts_handlers_styles_and_unsafe_protocols()
+    test_clean_readability_html_preserves_article_markup_and_secures_links()
+    test_sanitize_keeps_safe_mailto_and_removes_unsafe_data_image()
+    test_extract_sanitizes_rss_summary_fallback_before_response()

--- a/backend/poller/main.py
+++ b/backend/poller/main.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+from contextlib import suppress
 from datetime import datetime, timedelta, timezone
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
@@ -24,6 +25,10 @@ MAX_NEW_PER_FEED = int(os.getenv("MAX_NEW_ARTICLES_PER_FEED", "5"))
 MAX_ARTICLE_AGE_DAYS = int(os.getenv("MAX_ARTICLE_AGE_DAYS", "7"))
 # Minimum seconds between two consecutive LLM scoring calls (global, all feeds).
 SCORE_DELAY_SECONDS = float(os.getenv("SCORE_DELAY_SECONDS", "2.0"))
+# Durable scoring worker controls how many queued articles are claimed per pass.
+SCORING_CLAIM_BATCH_SIZE = int(os.getenv("SCORING_CLAIM_BATCH_SIZE", "5"))
+SCORING_WORKER_IDLE_SECONDS = float(os.getenv("SCORING_WORKER_IDLE_SECONDS", "15"))
+SCORING_WORKER_ERROR_SECONDS = float(os.getenv("SCORING_WORKER_ERROR_SECONDS", "30"))
 
 INTERNAL_HEADERS = {"X-Internal-Secret": API_SECRET, "Content-Type": "application/json"}
 
@@ -121,6 +126,51 @@ async def create_article(client: httpx.AsyncClient, payload: dict) -> dict:
     return resp.json()
 
 
+@retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=2, max=10))
+async def mark_feed_fetched(
+    client: httpx.AsyncClient,
+    feed_id: int,
+    entry_count: int,
+    fetched_at: str,
+) -> dict:
+    resp = await client.post(
+        f"{API_BASE}/api/internal/feeds/{feed_id}/fetched",
+        json={
+            "fetched_at": fetched_at,
+            "entry_count": entry_count,
+            "status": "parsed",
+        },
+        headers=INTERNAL_HEADERS,
+        timeout=30,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+@retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=2, max=10))
+async def claim_scoring_batch(client: httpx.AsyncClient, limit: int) -> dict | list:
+    resp = await client.post(
+        f"{API_BASE}/api/internal/scoring/claim",
+        json={"limit": limit},
+        headers=INTERNAL_HEADERS,
+        timeout=30,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+@retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=2, max=10))
+async def report_score_failed(client: httpx.AsyncClient, article_id: int, error: str) -> dict:
+    resp = await client.post(
+        f"{API_BASE}/api/internal/articles/{article_id}/score-failed",
+        json={"error": error[:2000]},
+        headers=INTERNAL_HEADERS,
+        timeout=30,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
 async def score_article_rate_limited(
     client: httpx.AsyncClient,
     article_id: int,
@@ -142,9 +192,120 @@ async def score_article_rate_limited(
                 timeout=120,
             )
             resp.raise_for_status()
+            return resp.json()
         finally:
             # Always wait, even on error, to avoid hammering the LLM on retries.
             await asyncio.sleep(SCORE_DELAY_SECONDS)
+
+
+def claim_items_from_response(data: dict | list) -> list[dict]:
+    """Accept the planned claim response, plus common aliases during API rollout."""
+    if isinstance(data, list):
+        items = data
+    elif isinstance(data, dict):
+        items = (
+            data.get("items")
+            or data.get("articles")
+            or data.get("claimed")
+            or data.get("claims")
+            or []
+        )
+    else:
+        items = []
+    return [item for item in items if isinstance(item, dict)]
+
+
+def compact_error(exc: Exception) -> str:
+    if isinstance(exc, httpx.HTTPStatusError):
+        if exc.response is None:
+            return str(exc)[:500]
+        response_text = exc.response.text[:500]
+        return f"HTTP {exc.response.status_code}: {response_text}"
+    return str(exc)[:500]
+
+
+def scoring_item_article_id(item: dict) -> int | None:
+    article_id = item.get("article_id", item.get("id"))
+    try:
+        return int(article_id)
+    except (TypeError, ValueError):
+        return None
+
+
+async def process_scoring_item(client: httpx.AsyncClient, item: dict):
+    article_id = scoring_item_article_id(item)
+    if article_id is None:
+        logger.warning("Skipping malformed scoring claim", item=item)
+        return
+
+    attempts = item.get("attempts", item.get("scoring_attempts"))
+    next_retry_at = item.get("next_retry_at", item.get("next_retry"))
+    log = logger.bind(article_id=article_id, attempts=attempts, next_retry_at=next_retry_at)
+
+    log.info("Scoring claimed article", status=item.get("status", "claimed"))
+    try:
+        result = await score_article_rate_limited(
+            client,
+            article_id,
+            item.get("title") or "",
+            item.get("content_text") or "",
+            item.get("rss_summary") or item.get("summary") or "",
+        )
+        log.info("Scoring completed", status=result.get("status", "ok") if isinstance(result, dict) else "ok")
+    except Exception as exc:
+        error = compact_error(exc)
+        try:
+            failure = await report_score_failed(client, article_id, error)
+        except Exception as report_exc:
+            log.error(
+                "Scoring failed and failure report failed",
+                status="report_failed",
+                error=error,
+                report_error=compact_error(report_exc),
+            )
+            return
+
+        if isinstance(failure, dict):
+            attempts = failure.get("attempts", attempts)
+            next_retry_at = failure.get("next_retry_at", failure.get("next_retry", next_retry_at))
+            status = failure.get("status", "failed")
+        else:
+            status = "failed"
+
+        log.error(
+            "Scoring failed",
+            status=status,
+            error=error,
+            attempts=attempts,
+            next_retry_at=next_retry_at,
+        )
+
+
+async def scoring_worker_loop():
+    logger.info(
+        "Scoring worker running",
+        claim_batch_size=SCORING_CLAIM_BATCH_SIZE,
+        score_delay_s=SCORE_DELAY_SECONDS,
+    )
+    async with httpx.AsyncClient() as client:
+        while True:
+            try:
+                claimed = await claim_scoring_batch(client, SCORING_CLAIM_BATCH_SIZE)
+                items = claim_items_from_response(claimed)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.error("Failed to claim scoring batch", error=compact_error(exc))
+                await asyncio.sleep(SCORING_WORKER_ERROR_SECONDS)
+                continue
+
+            if not items:
+                await asyncio.sleep(SCORING_WORKER_IDLE_SECONDS)
+                continue
+
+            logger.info("Claimed scoring batch", count=len(items))
+            for item in items:
+                await process_scoring_item(client, item)
 
 
 # ---------------------------------------------------------------------------
@@ -211,6 +372,15 @@ async def process_feed(client: httpx.AsyncClient, feed: dict):
 
     all_entries = parsed.entries
     log.info(f"Feed has {len(all_entries)} entries in RSS")
+    try:
+        await mark_feed_fetched(
+            client,
+            feed_id,
+            len(all_entries),
+            datetime.now(tz=timezone.utc).isoformat(),
+        )
+    except Exception as e:
+        log.warning("Failed to mark feed fetched", feed_id=feed_id, error=str(e))
 
     # 1. Sort entries newest-first BEFORE any filtering.
     #    This is critical: it ensures MAX_NEW_PER_FEED always captures the
@@ -314,19 +484,14 @@ async def process_feed(client: httpx.AsyncClient, feed: dict):
 
         article_id = result["id"]
         new_count += 1
-        log.info("Article stored, sending to scorer", article_id=article_id, new_count=new_count)
-
-        try:
-            await score_article_rate_limited(
-                client,
-                article_id,
-                extracted.get("title") or rss_title,
-                extracted.get("content_text") or rss_summary,
-                rss_summary,
-            )
-            log.info("Article scored", article_id=article_id)
-        except Exception as e:
-            log.error("Scoring failed", article_id=article_id, error=str(e))
+        log.info(
+            "Article stored for durable scoring",
+            article_id=article_id,
+            new_count=new_count,
+            status=result.get("scoring_status", "queued"),
+            attempts=result.get("scoring_attempts"),
+            next_retry_at=result.get("scoring_next_retry_at"),
+        )
 
     log.info(f"Feed done: {new_count} new articles ingested")
 
@@ -345,8 +510,14 @@ async def poll_all_feeds():
             logger.error("Failed to fetch feeds", error=str(e))
             return
 
-        # Process feeds concurrently — scoring is serialised by _score_semaphore.
-        await asyncio.gather(*[process_feed(client, feed) for feed in feeds], return_exceptions=True)
+        # Process feeds concurrently; durable scoring runs in its own worker loop.
+        results = await asyncio.gather(
+            *[process_feed(client, feed) for feed in feeds],
+            return_exceptions=True,
+        )
+        for result in results:
+            if isinstance(result, Exception):
+                logger.error("Feed processing task failed", error=compact_error(result))
 
     logger.info("Poll cycle complete")
 
@@ -385,12 +556,18 @@ async def main():
     )
     scheduler.start()
     logger.info(f"Scheduler running, interval={FETCH_INTERVAL_MINUTES}min")
+    scoring_task = asyncio.create_task(scoring_worker_loop(), name="scoring_worker")
 
     try:
         while True:
             await asyncio.sleep(3600)
     except (KeyboardInterrupt, SystemExit):
+        pass
+    finally:
         scheduler.shutdown()
+        scoring_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await scoring_task
 
 
 if __name__ == "__main__":

--- a/backend/scorer/prompt.py
+++ b/backend/scorer/prompt.py
@@ -64,3 +64,28 @@ Return exactly this JSON shape:
   "summary_bullets": ["2 to 3 short factual bullets grounded in the article"],
   "reason": "one concise sentence explaining the strongest positive signal and the main limitation"
 }"""
+
+
+JSON_RETRY_PROMPT = """You are MakhalReader's scoring repair pass.
+
+The previous response was malformed, incomplete, or not valid JSON.
+Return one valid JSON object only. No markdown, no prose outside JSON.
+
+Use the article context and the previous malformed response as evidence. If the
+article context is thin or the malformed response is ambiguous, choose
+conservative axis values and lower confidence.
+
+Return exactly this JSON shape:
+{
+  "topic_fit": 0.0,
+  "technical_depth": 0.0,
+  "operational_value": 0.0,
+  "strategic_value": 0.0,
+  "novelty": 0.0,
+  "noise_penalty": 0.0,
+  "confidence": 0.0,
+  "content_type": "release",
+  "tags": ["1 to 5 precise English technical tags"],
+  "summary_bullets": ["2 to 3 short factual bullets grounded in the article"],
+  "reason": "one concise sentence explaining the strongest positive signal and the main limitation"
+}"""

--- a/backend/scorer/scorer.py
+++ b/backend/scorer/scorer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 import re
@@ -7,15 +9,18 @@ import httpx
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field, field_validator
 
-from prompt import SYSTEM_PROMPT
+from prompt import JSON_RETRY_PROMPT, SYSTEM_PROMPT
 
 app = FastAPI(title="MakhalReader Scorer")
+
+SCORING_VERSION = 3
 
 # Generic OpenAI-compatible endpoint (highest priority when set): point it at any
 # OpenAI-compatible server (vLLM, llama.cpp, LM Studio, Groq, Together, OpenAI…).
 LLM_BASE_URL = os.getenv("LLM_BASE_URL", "").strip()
 LLM_API_KEY = os.getenv("LLM_API_KEY", "")
 LLM_MODEL = os.getenv("LLM_MODEL", "")
+LLM_DISABLE_FALLBACK = os.getenv("LLM_DISABLE_FALLBACK", "").strip().lower() in {"1", "true", "yes", "on"}
 
 OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY", "")
 SCORER_MODEL = os.getenv("SCORER_MODEL", "google/gemini-flash-1.5")
@@ -30,6 +35,8 @@ def _chat_completions_url(base: str) -> str:
     if base.endswith("/chat/completions"):
         return base
     return f"{base}/chat/completions"
+
+
 API_SECRET = os.getenv("API_SECRET", "changeme")
 
 INTERNAL_HEADERS = {"X-Internal-Secret": API_SECRET, "Content-Type": "application/json"}
@@ -48,6 +55,206 @@ NUMERIC_FIELDS = AXIS_FIELDS | {"confidence"}
 
 def clamp(value: float, low: float, high: float) -> float:
     return max(low, min(high, value))
+
+
+def provider_metadata(
+    provider: str,
+    model: str,
+    *,
+    response_model: Optional[str] = None,
+    finish_reason: Optional[str] = None,
+    base_url: Optional[str] = None,
+) -> dict[str, str]:
+    metadata = {
+        "provider": provider,
+        "provider_model": response_model or model or "unknown",
+    }
+    if model and response_model and response_model != model:
+        metadata["provider_configured_model"] = model
+    if finish_reason:
+        metadata["provider_finish_reason"] = finish_reason
+    if base_url:
+        metadata["provider_base_url"] = base_url
+    return metadata
+
+
+def add_provider_metadata(result: ScoreResult, metadata: dict[str, str]) -> ScoreResult:
+    result.score_details.update(metadata)
+    return result
+
+
+def normalize_llm_content(content: Any) -> Optional[str]:
+    """Normalize common chat content shapes into text without raising."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, dict):
+        for key in ("text", "content"):
+            value = content.get(key)
+            if isinstance(value, str):
+                return value
+        return json.dumps(content)
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                for key in ("text", "content"):
+                    value = item.get(key)
+                    if isinstance(value, str):
+                        parts.append(value)
+                        break
+        text = "\n".join(part for part in parts if part.strip()).strip()
+        return text or None
+    return None
+
+
+def parse_response_json(provider: str, resp: httpx.Response) -> Optional[dict]:
+    try:
+        data = resp.json()
+    except Exception as e:
+        print(f"{provider}: response was not valid JSON: {e}; body={resp.text[:300]}")
+        return None
+    if not isinstance(data, dict):
+        print(f"{provider}: response JSON was not an object: {str(data)[:300]}")
+        return None
+    return data
+
+
+def extract_openai_chat_content(data: dict, provider: str, configured_model: str = "") -> tuple[Optional[str], dict[str, str]]:
+    response_model = data.get("model") if isinstance(data.get("model"), str) else None
+    choices = data.get("choices")
+    if not isinstance(choices, list) or not choices:
+        print(f"{provider}: malformed response without choices: {str(data)[:300]}")
+        return None, provider_metadata(provider, configured_model, response_model=response_model)
+
+    choice = choices[0]
+    if not isinstance(choice, dict):
+        print(f"{provider}: malformed first choice: {str(choice)[:300]}")
+        return None, provider_metadata(provider, configured_model, response_model=response_model)
+
+    finish_reason = choice.get("finish_reason") if isinstance(choice.get("finish_reason"), str) else None
+    message = choice.get("message")
+    content = message.get("content") if isinstance(message, dict) else choice.get("text")
+    normalized = normalize_llm_content(content)
+    metadata = provider_metadata(provider, configured_model, response_model=response_model, finish_reason=finish_reason)
+    if normalized is None:
+        print(f"{provider}: response content was not usable text: {str(content)[:300]}")
+    return normalized, metadata
+
+
+def extract_ollama_chat_content(data: dict) -> tuple[Optional[str], dict[str, str]]:
+    response_model = data.get("model") if isinstance(data.get("model"), str) else OLLAMA_MODEL
+    message = data.get("message")
+    content = message.get("content") if isinstance(message, dict) else data.get("response")
+    normalized = normalize_llm_content(content)
+    metadata = provider_metadata("Ollama", OLLAMA_MODEL, response_model=response_model)
+    if normalized is None:
+        print(f"Ollama: response content was not usable text: {str(content)[:300]}")
+    return normalized, metadata
+
+
+def build_retry_message(user_message: str, bad_content: str) -> str:
+    clipped_bad_content = bad_content.strip()[:1800]
+    return (
+        f"{user_message}\n\n"
+        "Previous malformed response to repair or replace:\n"
+        f"{clipped_bad_content or '(empty response)'}"
+    )
+
+
+async def post_openai_chat(
+    client: httpx.AsyncClient,
+    *,
+    provider: str,
+    url: str,
+    headers: dict[str, str],
+    model: str,
+    system_prompt: str,
+    user_message: str,
+    timeout: float,
+) -> Optional[dict]:
+    try:
+        resp = await client.post(
+            url,
+            headers=headers,
+            json={
+                "model": model,
+                "messages": [
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_message},
+                ],
+                "temperature": 0.0,
+                "max_tokens": 1200,
+            },
+            timeout=timeout,
+        )
+    except Exception as e:
+        print(f"{provider} scoring request failed: {e}")
+        return None
+
+    if not resp.is_success:
+        print(f"{provider} error {resp.status_code}: {resp.text[:500]}")
+        return None
+    return parse_response_json(provider, resp)
+
+
+async def score_openai_chat_provider(
+    client: httpx.AsyncClient,
+    *,
+    provider: str,
+    url: str,
+    headers: dict[str, str],
+    model: str,
+    user_message: str,
+    article_words: int,
+    summary_words: int,
+    timeout: float = 60,
+    base_url: Optional[str] = None,
+) -> Optional[ScoreResult]:
+    data = await post_openai_chat(
+        client,
+        provider=provider,
+        url=url,
+        headers=headers,
+        model=model,
+        system_prompt=SYSTEM_PROMPT,
+        user_message=user_message,
+        timeout=timeout,
+    )
+    if not data:
+        return None
+
+    content, metadata = extract_openai_chat_content(data, provider, model)
+    if base_url:
+        metadata["provider_base_url"] = base_url
+    if not content:
+        return None
+
+    result = build_result_from_llm_content(provider, content, article_words, summary_words, metadata)
+    if result is not None:
+        return result
+
+    retry_data = await post_openai_chat(
+        client,
+        provider=f"{provider} JSON retry",
+        url=url,
+        headers=headers,
+        model=model,
+        system_prompt=JSON_RETRY_PROMPT,
+        user_message=build_retry_message(user_message, content),
+        timeout=timeout,
+    )
+    if not retry_data:
+        return None
+
+    retry_content, retry_metadata = extract_openai_chat_content(retry_data, provider, model)
+    if base_url:
+        retry_metadata["provider_base_url"] = base_url
+    retry_metadata["provider_retry"] = "json-only"
+    if not retry_content:
+        return None
+    return build_result_from_llm_content(provider, retry_content, article_words, summary_words, retry_metadata)
 
 
 class ScoreRequest(BaseModel):
@@ -165,11 +372,45 @@ def json_candidates(text: str) -> list[str]:
         else:
             candidates.append(text[first_brace:].strip())
 
+    candidates.extend(balanced_json_objects(text))
+
     unique: list[str] = []
     for candidate in candidates:
         if candidate and candidate not in unique:
             unique.append(candidate)
     return unique
+
+
+def balanced_json_objects(text: str) -> list[str]:
+    objects: list[str] = []
+    start: Optional[int] = None
+    depth = 0
+    in_string = False
+    escape = False
+
+    for idx, char in enumerate(text):
+        if in_string:
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == '"':
+                in_string = False
+            continue
+
+        if char == '"':
+            in_string = True
+        elif char == "{":
+            if depth == 0:
+                start = idx
+            depth += 1
+        elif char == "}" and depth:
+            depth -= 1
+            if depth == 0 and start is not None:
+                objects.append(text[start : idx + 1].strip())
+                start = None
+
+    return objects
 
 
 def extract_partial_analysis(text: str) -> Optional[dict]:
@@ -355,7 +596,7 @@ def build_result(analysis: ScoreAnalysis, article_words: int, summary_words: int
         "summary_words": summary_words,
         "caps": caps,
         "adjustments": adjustments,
-        "scoring_version": 3,
+        "scoring_version": SCORING_VERSION,
     }
     return ScoreResult(
         score=score,
@@ -371,6 +612,7 @@ def build_result_from_llm_content(
     content: str,
     article_words: int,
     summary_words: int,
+    metadata: Optional[dict[str, str]] = None,
 ) -> Optional[ScoreResult]:
     parsed = extract_json_from_text(content)
     if not parsed:
@@ -378,7 +620,10 @@ def build_result_from_llm_content(
         return None
 
     try:
-        return build_result(validate_analysis(parsed), article_words, summary_words)
+        result = build_result(validate_analysis(parsed), article_words, summary_words)
+        if metadata:
+            add_provider_metadata(result, metadata)
+        return result
     except Exception as e:
         print(f"{provider}: invalid score payload after JSON parse: {e}; response={content[:300]}")
         return None
@@ -398,31 +643,18 @@ async def score_with_openai_compatible(
     if LLM_API_KEY:
         headers["Authorization"] = f"Bearer {LLM_API_KEY}"
 
-    try:
-        resp = await client.post(
-            _chat_completions_url(LLM_BASE_URL),
-            headers=headers,
-            json={
-                "model": LLM_MODEL,
-                "messages": [
-                    {"role": "system", "content": SYSTEM_PROMPT},
-                    {"role": "user", "content": user_message},
-                ],
-                "temperature": 0.0,
-                "max_tokens": 1200,
-            },
-            timeout=60,
-        )
-        if not resp.is_success:
-            print(f"OpenAI-compatible endpoint error {resp.status_code}: {resp.text[:500]}")
-            return None
-        data = resp.json()
-        content = data["choices"][0]["message"]["content"]
-        return build_result_from_llm_content("OpenAI-compatible", content, article_words, summary_words)
-    except Exception as e:
-        print(f"OpenAI-compatible scoring failed: {e}")
-
-    return None
+    return await score_openai_chat_provider(
+        client,
+        provider="OpenAI-compatible",
+        url=_chat_completions_url(LLM_BASE_URL),
+        headers=headers,
+        model=LLM_MODEL,
+        user_message=user_message,
+        article_words=article_words,
+        summary_words=summary_words,
+        timeout=60,
+        base_url=LLM_BASE_URL,
+    )
 
 
 async def score_with_openrouter(
@@ -434,36 +666,22 @@ async def score_with_openrouter(
     if not OPENROUTER_API_KEY or not OPENROUTER_API_KEY.startswith("sk-"):
         return None
 
-    try:
-        resp = await client.post(
-            "https://openrouter.ai/api/v1/chat/completions",
-            headers={
-                "Authorization": f"Bearer {OPENROUTER_API_KEY}",
-                "Content-Type": "application/json",
-                "HTTP-Referer": "https://github.com/makhalreader",
-                "X-Title": "MakhalReader",
-            },
-            json={
-                "model": SCORER_MODEL,
-                "messages": [
-                    {"role": "system", "content": SYSTEM_PROMPT},
-                    {"role": "user", "content": user_message},
-                ],
-                "temperature": 0.0,
-                "max_tokens": 1200,
-            },
-            timeout=60,
-        )
-        if not resp.is_success:
-            print(f"OpenRouter error {resp.status_code}: {resp.text[:500]}")
-            return None
-        data = resp.json()
-        content = data["choices"][0]["message"]["content"]
-        return build_result_from_llm_content("OpenRouter", content, article_words, summary_words)
-    except Exception as e:
-        print(f"OpenRouter scoring failed: {e}")
-
-    return None
+    return await score_openai_chat_provider(
+        client,
+        provider="OpenRouter",
+        url="https://openrouter.ai/api/v1/chat/completions",
+        headers={
+            "Authorization": f"Bearer {OPENROUTER_API_KEY}",
+            "Content-Type": "application/json",
+            "HTTP-Referer": "https://github.com/makhalreader",
+            "X-Title": "MakhalReader",
+        },
+        model=SCORER_MODEL,
+        user_message=user_message,
+        article_words=article_words,
+        summary_words=summary_words,
+        timeout=60,
+    )
 
 
 async def score_with_ollama(
@@ -496,9 +714,50 @@ async def score_with_ollama(
         if not resp.is_success:
             print(f"Ollama error {resp.status_code}: {resp.text[:300]}")
             return None
-        data = resp.json()
-        content = data["message"]["content"]
-        return build_result_from_llm_content("Ollama", content, article_words, summary_words)
+        data = parse_response_json("Ollama", resp)
+        if not data:
+            return None
+        content, metadata = extract_ollama_chat_content(data)
+        if not content:
+            return None
+        result = build_result_from_llm_content("Ollama", content, article_words, summary_words, metadata)
+        if result is not None:
+            return result
+
+        retry_resp = await client.post(
+            f"{OLLAMA_URL}/api/chat",
+            json={
+                "model": OLLAMA_MODEL,
+                "messages": [
+                    {"role": "system", "content": JSON_RETRY_PROMPT},
+                    {"role": "user", "content": build_retry_message(user_message, content)},
+                ],
+                "stream": False,
+                "format": "json",
+                "options": {
+                    "temperature": 0.0,
+                    "num_predict": 900,
+                },
+            },
+            timeout=120,
+        )
+        if not retry_resp.is_success:
+            print(f"Ollama JSON retry error {retry_resp.status_code}: {retry_resp.text[:300]}")
+            return None
+        retry_data = parse_response_json("Ollama JSON retry", retry_resp)
+        if not retry_data:
+            return None
+        retry_content, retry_metadata = extract_ollama_chat_content(retry_data)
+        retry_metadata["provider_retry"] = "json-only"
+        if not retry_content:
+            return None
+        return build_result_from_llm_content(
+            "Ollama",
+            retry_content,
+            article_words,
+            summary_words,
+            retry_metadata,
+        )
     except Exception as e:
         print(f"Ollama scoring failed: {e}")
 
@@ -582,14 +841,16 @@ async def score_article(req: ScoreRequest):
         user_message, article_words, summary_words = build_user_message(req, preference_block)
 
         if LLM_BASE_URL:
-            # Explicit OpenAI-compatible endpoint — used exclusively, no fallback.
             result = await score_with_openai_compatible(client, user_message, article_words, summary_words)
-        else:
+
+        if result is None and not (LLM_BASE_URL and LLM_DISABLE_FALLBACK):
             if OPENROUTER_API_KEY and OPENROUTER_API_KEY.startswith("sk-"):
                 result = await score_with_openrouter(client, user_message, article_words, summary_words)
 
             if result is None:
                 result = await score_with_ollama(client, user_message, article_words, summary_words)
+        elif result is None:
+            print("Scoring fallback disabled by LLM_DISABLE_FALLBACK after LLM_BASE_URL failure.")
 
         if result is None:
             raise HTTPException(
@@ -620,7 +881,11 @@ async def score_article(req: ScoreRequest):
 
 @app.get("/health")
 async def health():
-    return {"status": "ok"}
+    return {
+        "status": "ok",
+        "scoring_version": SCORING_VERSION,
+        "llm_fallback_disabled": LLM_DISABLE_FALLBACK,
+    }
 
 
 if __name__ == "__main__":

--- a/backend/scorer/tests/test_scoring.py
+++ b/backend/scorer/tests/test_scoring.py
@@ -1,3 +1,4 @@
+import asyncio
 import sys
 import unittest
 from pathlib import Path
@@ -5,7 +6,15 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from scorer import ScoreAnalysis, build_result
+from scorer import (
+    SCORING_VERSION,
+    ScoreAnalysis,
+    build_result,
+    build_result_from_llm_content,
+    extract_openai_chat_content,
+    health,
+    normalize_llm_content,
+)
 
 
 class ScoringCalibrationTest(unittest.TestCase):
@@ -27,6 +36,8 @@ class ScoringCalibrationTest(unittest.TestCase):
         result = build_result(analysis, article_words=450, summary_words=35)
 
         self.assertEqual(result.score, 6.2)
+        self.assertEqual(result.score_details["scoring_version"], SCORING_VERSION)
+        self.assertEqual(result.score_details["scoring_version"], 3)
         self.assertEqual(result.score_details["adjustments"], ["practical-note", "practical-floor"])
         self.assertEqual(result.score_details["caps"], [])
 
@@ -49,6 +60,105 @@ class ScoringCalibrationTest(unittest.TestCase):
 
         self.assertLess(result.score, 5.0)
         self.assertEqual(result.score_details["adjustments"], [])
+
+    def test_health_exposes_scoring_version(self):
+        payload = asyncio.run(health())
+
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["scoring_version"], 3)
+
+    def test_malformed_json_with_prose_is_recovered(self):
+        content = """
+        Here is the score:
+        ```json
+        {
+          "topic_fit": 2.5,
+          "technical_depth": 1.6,
+          "operational_value": 2.2,
+          "strategic_value": IE 0.8,
+          "novelty": 1.4,
+          "noise_penalty": 0.6,
+          "confidence": 0.82,
+          "content_type": "tutorial",
+          "tags": ["kubernetes", "debugging"],
+          "summary_bullets": ["Shows concrete debugging steps."],
+          "reason": "Concrete operational guidance with modest novelty.",
+        }
+        ```
+        """
+
+        result = build_result_from_llm_content(
+            "OpenRouter",
+            content,
+            article_words=700,
+            summary_words=50,
+            metadata={"provider": "OpenRouter", "provider_model": "test/model"},
+        )
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result.score_details["provider"], "OpenRouter")
+        self.assertEqual(result.score_details["provider_model"], "test/model")
+        self.assertEqual(result.score_details["content_type"], "tutorial")
+        self.assertGreater(result.score, 5.0)
+
+    def test_openai_payload_helper_handles_fragment_content_and_metadata(self):
+        content, metadata = extract_openai_chat_content(
+            {
+                "model": "served/model",
+                "choices": [
+                    {
+                        "finish_reason": "stop",
+                        "message": {
+                            "content": [
+                                {"type": "text", "text": '{"topic_fit": 2.0}'},
+                                {"type": "text", "text": '\n'},
+                            ]
+                        },
+                    }
+                ],
+            },
+            "OpenAI-compatible",
+            configured_model="configured/model",
+        )
+
+        self.assertEqual(content, '{"topic_fit": 2.0}')
+        self.assertEqual(metadata["provider"], "OpenAI-compatible")
+        self.assertEqual(metadata["provider_model"], "served/model")
+        self.assertEqual(metadata["provider_configured_model"], "configured/model")
+        self.assertEqual(metadata["provider_finish_reason"], "stop")
+
+    def test_openai_payload_helper_handles_empty_choices_without_raising(self):
+        content, metadata = extract_openai_chat_content(
+            {"choices": []},
+            "OpenAI-compatible",
+            configured_model="configured/model",
+        )
+
+        self.assertIsNone(content)
+        self.assertEqual(metadata["provider_model"], "configured/model")
+
+    def test_non_string_content_dict_can_be_scored(self):
+        content = normalize_llm_content(
+            {
+                "topic_fit": 2.0,
+                "technical_depth": 1.5,
+                "operational_value": 1.8,
+                "strategic_value": 1.1,
+                "novelty": 1.0,
+                "noise_penalty": 0.7,
+                "confidence": 0.75,
+                "content_type": "tutorial",
+                "tags": ["ops"],
+                "summary_bullets": ["Contains practical steps."],
+                "reason": "Useful practical note.",
+            }
+        )
+
+        self.assertIsInstance(content, str)
+        assert content is not None
+        result = build_result_from_llm_content("OpenAI-compatible", content, article_words=350, summary_words=40)
+        self.assertIsNotNone(result)
 
 
 if __name__ == "__main__":

--- a/docs/api.md
+++ b/docs/api.md
@@ -100,6 +100,10 @@ Message SSE :
 }
 ```
 
+Les evenements `new_article` sont emis apres persistance du score par la route
+interne de scoring. Un article cree mais encore `score IS NULL` ne doit pas etre
+interprete comme un nouvel article score par le flux temps reel.
+
 ## Highlights
 
 | Methode | Chemin | Description |
@@ -133,7 +137,36 @@ Ces routes doivent toujours recevoir `X-Internal-Secret: <API_SECRET>`.
 | `GET` | `/api/internal/feedback-examples` | `scorer` |
 | `GET` | `/api/internal/articles/exists` | `poller` |
 | `POST` | `/api/internal/articles` | `poller` |
+| `POST` | `/api/internal/feeds/{feed_id}/fetched` | `poller` |
+| `POST` | `/api/internal/scoring/claim` | `poller` scoring worker |
+| `POST` | `/api/internal/articles/{article_id}/score-failed` | `poller` scoring worker |
+| `GET` | `/api/internal/scoring/stats` | operations |
+| `POST` | `/api/internal/scoring/requeue-failed` | operations |
 | `POST` | `/api/internal/articles/{article_id}/score` | `scorer` |
+
+Contrats internes :
+
+- `POST /api/internal/articles` cree l'article avant le scoring et retourne
+  `{"id": ..., "created": false}` pour les doublons URL/titre recent. Les
+  nouveaux articles sont initialises avec `scoring_status="queued"`.
+- `POST /api/internal/scoring/claim` reclame un lot d'articles `queued`/`retry`
+  ou `processing` avec lock expire. La route passe les lignes en
+  `processing`, incremente `score_attempts`, pose `score_locked_at`, puis
+  retourne `{"items": [...]}`.
+- `POST /api/internal/articles/{article_id}/score-failed` nettoie le lock et
+  passe l'article en `retry` avec `next_score_attempt_at`, ou `failed` apres
+  `SCORING_MAX_ATTEMPTS`.
+- `POST /api/internal/scoring/requeue-failed?limit=100` remet des articles
+  `failed` sans score en `queued` apres correction de configuration ou de
+  modele LLM.
+- `POST /api/internal/articles/{article_id}/score` est idempotent pour le meme
+  article : il remplace `score`, `score_details_json`, `tags_json`,
+  `summary_bullets_json` et `reason`, marque `scoring_status="done"`, renseigne
+  `scored_at`, puis diffuse le SSE `new_article`.
+- `score IS NULL` est le signal d'un article non score ou a relancer. Les clients
+  ne doivent pas assimiler cette valeur a `0`.
+- Les workers doivent journaliser leurs echecs et compter sur une relance/requeue
+  plutot que recreer l'article.
 
 ## Services internes
 
@@ -143,6 +176,23 @@ Ces routes doivent toujours recevoir `X-Internal-Secret: <API_SECRET>`.
 | `scorer` | `POST` | `/score` | Score un article puis poste le resultat a l'API |
 | `scorer` | `GET` | `/health` | Sante du service scorer |
 
+Contrat `extractor /extract` :
+
+- `content_text` est le champ canonique pour scoring et recherche.
+- `content_html` est du HTML de lecture non fiable cote navigateur; il doit etre
+  rendu seulement par les composants prevus pour cela.
+- `extraction_failed=true` indique un fallback faible, pas une erreur HTTP du
+  endpoint.
+
+Contrat health/version :
+
+- `/api/health` est public et doit rester utilisable par Docker sans auth.
+- Le payload minimal historique est `{"status":"ok"}`.
+- `scorer /health` expose `scoring_version`; c'est le point rapide pour verifier
+  qu'un rebuild du scorer a bien pris le code de calibration courant.
+- Si des metadata de build/runtime sont ajoutees, les docs operations doivent
+  verifier leur coherence apres `docker compose up -d --build`.
+
 ## Routes admin
 
 | Methode | Chemin | Description |
@@ -151,4 +201,3 @@ Ces routes doivent toujours recevoir `X-Internal-Secret: <API_SECRET>`.
 | `POST` | `/api/admin/normalize-urls` | Normalise les URLs existantes et fusionne des doublons |
 
 Ces routes sont protegees par session, mais pas par role distinct. A utiliser avec prudence.
-

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,10 +49,26 @@ api
 4. Les entrees sont triees par date descendante, puis filtrees par `MAX_ARTICLE_AGE_DAYS`.
 5. `poller` normalise l'URL, verifie l'existence via `/api/internal/articles/exists`, puis appelle `extractor /extract`.
 6. `extractor` renvoie titre, HTML, texte, images, auteur, temps de lecture et URL canonique eventuelle.
-7. `poller` cree l'article via `POST /api/internal/articles`.
-8. `poller` appelle `scorer /score` avec le texte extrait.
-9. `scorer` construit un profil de preferences via `/api/internal/feedback-examples`, interroge le LLM, valide une analyse structuree, calcule le score final et poste le resultat sur `/api/internal/articles/{id}/score`.
-10. `api` persiste le score et diffuse l'article aux clients SSE.
+7. `poller` cree l'article via `POST /api/internal/articles`; l'API le place en
+   `scoring_status="queued"`.
+8. Le worker de scoring du `poller` reclame des lots via
+   `POST /api/internal/scoring/claim`.
+9. Pour chaque article reclame, le worker appelle `scorer /score` avec le texte
+   extrait. En cas d'echec, il poste sur
+   `/api/internal/articles/{id}/score-failed` pour programmer un retry ou passer
+   en `failed`.
+10. `scorer` construit un profil de preferences via
+    `/api/internal/feedback-examples`, interroge le LLM, valide une analyse
+    structuree, calcule le score final et poste le resultat sur
+    `/api/internal/articles/{id}/score`.
+11. `api` persiste le score, marque `scoring_status="done"` et diffuse l'article
+    aux clients SSE.
+
+Le point durable du flux est l'etape 7 : une fois l'article cree, un echec de
+scoring ne perd pas l'article. La file de rattrapage operationnelle est portee
+par `scoring_status`, `score_attempts`, `next_score_attempt_at` et
+`score_last_error`; `score IS NULL` reste le signal public des articles non
+scores.
 
 ## Flux utilisateur
 
@@ -68,5 +84,8 @@ api
 - SQLite est centralise dans `api`; les autres services passent par des endpoints internes plutot que d'ecrire directement en base.
 - Les migrations sont additives et executees au demarrage dans `init_db()`.
 - Le scoring est separe en deux etapes : le LLM produit des axes, puis le code calcule le score final 0-10. Cela reduit la derive du prompt.
+- Le HTML extrait est une representation de lecture, pas une source de verite
+  securisee. `content_text` reste le contrat robuste pour les traitements IA.
+- `score_details_json.scoring_version` est le marqueur de derive de calibration
+  pour les scores deja persistes.
 - Le proxy `web` est obligatoire pour que les chemins relatifs frontend (`/api/*`, `/auth/*`) fonctionnent en local comme en production.
-

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -48,8 +48,19 @@ Points cles :
 - ignore les articles plus vieux que `MAX_ARTICLE_AGE_DAYS`;
 - limite les nouveaux articles par feed avec `MAX_NEW_ARTICLES_PER_FEED`;
 - normalise les URLs et retire les parametres de tracking;
-- appelle extractor puis scorer;
-- serialize les appels LLM avec un semaphore global et `SCORE_DELAY_SECONDS`.
+- appelle extractor puis cree l'article via l'API;
+- met a jour `feeds.last_fetched` apres une lecture RSS reussie;
+- lance un worker de scoring durable qui reclame des lots via l'API;
+- serialize les appels LLM avec un semaphore global et `SCORE_DELAY_SECONDS`;
+- reporte les echecs de scoring a l'API pour backoff/retry au lieu de perdre
+  l'article.
+
+Les appels HTTP du poller vers `api`, `extractor` et `scorer` sont retentes
+jusqu'a 3 fois avec backoff exponentiel. Si le scorer echoue encore, le poller
+poste `/api/internal/articles/{id}/score-failed`; l'API passe l'article en
+`retry` avec `next_score_attempt_at`, ou en `failed` apres
+`SCORING_MAX_ATTEMPTS`. Le contrat operationnel est de ne jamais dupliquer
+l'article pour relancer le scoring.
 
 ## Extractor
 
@@ -71,6 +82,20 @@ Strategies, dans l'ordre :
 10. fallback court sur resume RSS avec `extraction_failed=true`.
 
 L'extractor renvoie aussi une URL canonique quand un `<link rel="canonical">` fiable est trouve. Le poller l'utilise pour ameliorer la deduplication.
+
+### Contrat HTML
+
+`content_text` est la reference pour le scoring, la recherche et Ask AI.
+`content_html` est uniquement du HTML de lecture, issu de Readability,
+Trafilatura, arXiv, Reddit ou des fallbacks RSS. L'extractor nettoie surtout la
+structure lisible, resout les URLs relatives et retire certains wrappers, mais
+ce champ doit rester traite comme du HTML non fiable cote UI. Tout composant qui
+l'affiche doit conserver une surface restreinte et eviter d'ajouter des scripts,
+handlers inline ou transformations larges sans verification visuelle.
+
+Quand l'extraction est faible, `extraction_failed=true` signale que le contenu
+vient d'un fallback court, souvent le resume RSS. Ce flag ne bloque pas le
+scoring; il sert a diagnostiquer les articles peu riches.
 
 ## Scorer
 
@@ -101,6 +126,38 @@ Axes de scoring :
 - `content_type`
 
 Le champ `score_details_json` permet de comprendre pourquoi un article a ete cape ou favorise.
+
+### Contrat de scoring durable
+
+L'API est la source de verite du resultat de scoring. Le scorer ne modifie pas
+SQLite directement : il poste sur
+`POST /api/internal/articles/{article_id}/score` avec `X-Internal-Secret`.
+
+Semantique attendue :
+
+- `score IS NULL` signifie "article ingere mais pas encore score".
+- `score IS NOT NULL` signifie "scoring termine"; `score_details_json`,
+  `tags_json`, `summary_bullets_json` et `reason` doivent etre coherents avec ce
+  score.
+- `scoring_status` suit l'etat operationnel: `queued`, `processing`, `retry`,
+  `done`, `failed`.
+- Un echec scorer ne supprime pas l'article et ne doit pas creer de doublon.
+- Les relances doivent etre idempotentes pour un `article_id` donne : poster un
+  nouveau score remplace les champs de scoring du meme article.
+- Les articles `failed` peuvent etre remis dans la file avec
+  `POST /api/internal/scoring/requeue-failed?limit=100` apres correction de la
+  configuration LLM.
+- `score_details_json.scoring_version` permet de reperer les articles scores
+  avec une ancienne calibration.
+
+Inspection rapide depuis l'hote, sans supposer que le binaire `sqlite3` existe
+dans l'image `api` :
+
+```bash
+docker compose exec api python -c "import sqlite3; db=sqlite3.connect('/data/makhal.db'); print(db.execute(\"select count(*) from articles where score is null\").fetchone()[0])"
+docker compose exec api python -c "import sqlite3; db=sqlite3.connect('/data/makhal.db'); print(db.execute(\"select id, created_at, title from articles where score is null order by created_at desc limit 20\").fetchall())"
+docker compose exec api python -c "import sqlite3; db=sqlite3.connect('/data/makhal.db'); print(db.execute(\"select json_extract(score_details_json, '$.scoring_version'), count(*) from articles where score is not null group by 1 order by 1\").fetchall())"
+```
 
 ## Points de vigilance
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -15,7 +15,13 @@ Source de verite actuelle : `backend/api/database.py`.
 | `name` | string | Nom affiche |
 | `category` | string | Categorie UI |
 | `active` | boolean | Feed actif |
-| `last_fetched` | datetime | Dernier fetch connu |
+| `last_fetched` | datetime | Dernier fetch reussi connu, si le poller le maintient |
+
+`last_fetched` est une information operationnelle de feed, pas une preuve que
+toutes les entrees ont ete extraites ou scorees. Une implementation correcte le
+met a jour apres une lecture RSS reussie du feed, meme si certaines entrees sont
+ensuite ignorees comme anciennes, dedupliquees ou echouent au scoring. Si la
+colonne est `NULL`, traiter le feed comme jamais confirme par le poller courant.
 
 ### `articles`
 
@@ -42,10 +48,34 @@ Source de verite actuelle : `backend/api/database.py`.
 | `title_fingerprint` | string(16) | Dedup par titre |
 | `user_feedback` | integer | `1`, `-1` ou null |
 | `reading_time` | integer | Minutes estimees |
+| `scoring_status` | string | `queued`, `processing`, `retry`, `done`, `failed` |
+| `score_attempts` | integer | Nombre de claims de scoring |
+| `next_score_attempt_at` | datetime | Prochaine tentative apres backoff |
+| `score_last_error` | text | Derniere erreur compacte du scorer/poller |
+| `score_locked_at` | datetime | Verrou de traitement du worker |
+| `scored_at` | datetime | Date de persistance du score |
+
+Contrats importants :
+
+- `content_text` est la source de scoring/recherche/Ask AI.
+- `content_html` est du HTML de lecture produit par l'extractor; il peut venir
+  d'une page distante ou d'un flux RSS et doit etre traite comme non fiable par
+  le frontend.
+- `score IS NULL` represente un article en attente ou en echec de scoring; il ne
+  faut pas le confondre avec un score bas.
+- `scoring_status` represente l'etat operationnel du pipeline. `score IS NULL`
+  reste le contrat public le plus robuste pour detecter les articles non scores,
+  mais `scoring_status`, `score_attempts`, `next_score_attempt_at` et
+  `score_last_error` servent au diagnostic et au retry.
+- `score_details_json.scoring_version`, quand present, indique la calibration du
+  scorer qui a produit le score.
 
 Index important :
 
 - `ix_articles_title_fp_created` sur `title_fingerprint`, `created_at`.
+- `ix_articles_scoring_queue` sur `scoring_status`, `next_score_attempt_at`,
+  `created_at`.
+- `ix_articles_feed_created` sur `feed_id`, `created_at`.
 
 ### `highlights`
 
@@ -81,6 +111,10 @@ Index :
 
 Les erreurs sont ignorees pour permettre de relancer les migrations si une colonne existe deja. C'est simple et adapte a SQLite, mais il faut eviter les migrations destructives implicites.
 
+Les migrations additives doivent preserver les lignes existantes. Pour une queue
+de scoring durable, preferer des colonnes optionnelles ou avec defaults
+compatibles, afin que les anciens articles restent inspectables et relancables.
+
 ## Deduplication
 
 La deduplication combine :
@@ -91,3 +125,12 @@ La deduplication combine :
 
 Risque connu : des titres recurrents comme "Weekly Digest" peuvent provoquer des faux positifs si leurs titres normalises se ressemblent dans la fenetre.
 
+## Inspection SQLite sans CLI sqlite3
+
+Ne pas supposer que le binaire `sqlite3` est installe dans le conteneur `api`.
+Utiliser le module Python standard :
+
+```bash
+docker compose exec api python -c "import sqlite3; db=sqlite3.connect('/data/makhal.db'); print(db.execute('select count(*) from articles').fetchone()[0])"
+docker compose exec api python -c "import sqlite3; db=sqlite3.connect('/data/makhal.db'); print(db.execute('select id, title from articles where score is null order by created_at desc limit 10').fetchall())"
+```

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -20,9 +20,26 @@ docker compose -f docker-compose.yml -f docker-compose.npm.yml ps
 
 Attendu :
 
-- `/api/health` repond `200`.
+- `/api/health` repond `200` avec un JSON de sante. Si le contrat de metadata
+  est active, verifier aussi la presence de la version/build attendue; sinon le
+  payload minimal historique est `{"status":"ok"}`.
 - `/auth/status` repond `401` avant login.
 - Les services `api`, `frontend`, `web`, `poller`, `extractor`, `scorer` sont running.
+
+Checklist rebuild et derive de version :
+
+```bash
+docker compose up -d --build
+docker compose ps
+curl -s http://localhost/api/health
+docker compose exec api python -c "import urllib.request; print(urllib.request.urlopen('http://127.0.0.1:8000/api/health', timeout=5).read().decode())"
+docker compose logs --tail=50 api poller extractor scorer
+```
+
+Apres un rebuild, comparer le contenu de `/api/health`, l'heure de creation des
+conteneurs dans `docker compose ps` et les premieres lignes de logs. Si un
+service sert encore l'ancien comportement, reconstruire explicitement le service
+concerne, par exemple `docker compose up -d --build api scorer poller`.
 
 ## Logs utiles
 
@@ -45,9 +62,12 @@ docker compose -f docker-compose.yml -f docker-compose.npm.yml logs -f --tail=10
 Tout l'etat applicatif est dans SQLite sous `/data/makhal.db`, dans le volume Docker `data`.
 
 ```bash
-docker compose exec api sqlite3 /data/makhal.db ".backup /data/makhal.db.bak"
+docker compose exec api python -c "import sqlite3; src=sqlite3.connect('/data/makhal.db'); dst=sqlite3.connect('/data/makhal.db.bak'); src.backup(dst); dst.close(); src.close()"
 docker compose cp api:/data/makhal.db.bak ./makhal.db.bak
 ```
+
+Note : l'image `api` est basee sur `python:3.12-slim`; elle fournit le module
+Python `sqlite3`, mais pas forcement le binaire CLI `sqlite3`.
 
 Pour la production, ajouter `-f docker-compose.yml -f docker-compose.npm.yml` aux commandes Compose.
 
@@ -79,7 +99,7 @@ docker compose up -d api
 3. Optionnel : invalider toutes les sessions existantes.
 
 ```bash
-docker compose exec api sqlite3 /data/makhal.db "DELETE FROM auth_sessions;"
+docker compose exec api python -c "import sqlite3; db=sqlite3.connect('/data/makhal.db'); db.execute('DELETE FROM auth_sessions'); db.commit(); db.close()"
 ```
 
 ## Depannage
@@ -102,6 +122,34 @@ Verifier :
 - `SCORER_MODEL`/`OLLAMA_MODEL`;
 - logs `scorer`;
 - logs `poller` pour voir si le scoring est appele.
+
+Inspecter la queue durable implicite, c'est-a-dire les articles deja stockes
+mais sans score :
+
+```bash
+docker compose exec api python -c "import sqlite3; db=sqlite3.connect('/data/makhal.db'); print(db.execute(\"select count(*) from articles where score is null\").fetchone()[0])"
+docker compose exec api python -c "import sqlite3; db=sqlite3.connect('/data/makhal.db'); rows=db.execute(\"select id, created_at, title, extraction_failed from articles where score is null order by created_at desc limit 20\").fetchall(); [print(r) for r in rows]"
+```
+
+Pour distinguer un retard normal d'un echec durable :
+
+- si `poller` journalise `Article stored for durable scoring`, l'article est en
+  file et sera traite par le worker de scoring;
+- si `poller` journalise `Claimed scoring batch` puis `Scoring completed`, le
+  pipeline fonctionne;
+- si `poller` journalise `Scoring failed`, regarder `score_last_error`, l'erreur
+  HTTP/LLM dans `scorer`, et le prochain `next_score_attempt_at`;
+- si `scorer` journalise `Failed to post score to API`, verifier `API_SECRET` et
+  la route interne `/api/internal/articles/{id}/score`;
+- si les articles restent `score IS NULL` apres redemarrage, verifier
+  `/api/internal/scoring/stats` via le reseau interne ou inspecter SQLite; ne pas
+  recreer les articles a la main.
+
+Voir les versions de calibration deja persistees :
+
+```bash
+docker compose exec api python -c "import sqlite3; db=sqlite3.connect('/data/makhal.db'); rows=db.execute(\"select json_extract(score_details_json, '$.scoring_version') as version, count(*) from articles where score is not null group by version order by version\").fetchall(); [print(r) for r in rows]"
+```
 
 ### Trop d'articles ou cout LLM trop eleve
 
@@ -134,4 +182,3 @@ Puis adapter `docker-compose.npm.yml` ou connecter MakhalReader au bon reseau ex
 - `CORS_ORIGIN` exact, sans slash final.
 - NPM pointe vers `makhal-reader-web:80`.
 - Ports `8000`, `8001`, `8002` non exposes publiquement.
-


### PR DESCRIPTION
## Summary

- Adds a durable scoring queue around article ingestion, with claim/retry/failure bookkeeping in the API and poller.
- Hardens scorer JSON handling, provider metadata, retry prompts, and fallback behavior.
- Sanitizes extracted article HTML and RSS fallback content before it reaches the reader UI.
- Updates API/data-model/backend/operations docs for the new contracts.

## Root Cause / Context

The app could ingest an article before scoring, but failures were not durable enough: unscored articles could be lost in practice, retries were not explicit, and worker/API interactions could monopolize the API event loop. The auth loading issue came from `/auth/status` waiting behind synchronous DB-heavy internal routes exposed as async endpoints.

## Impact

Articles now remain recoverable through `score IS NULL` plus explicit scoring status fields. Poller/scorer interactions are retryable, and the frontend auth gate no longer stays stuck on `Loading...` when internal workers are busy.

## Validation

- `docker compose up -d --build api`
- `docker compose run --rm --no-deps api pytest` (`21 passed`)
- `docker compose build extractor`
- `docker compose run --rm --no-deps extractor python tests/test_sanitization.py`
- `docker compose build scorer poller`
- `docker compose run --rm --no-deps scorer python -m unittest discover -s tests`
- `docker compose run --rm --no-deps poller python -m py_compile main.py`
- `git diff --check`
- Browser check on `http://localhost/`: auth page renders, no longer stuck on `Loading...`